### PR TITLE
Limit string split to "2" #7

### DIFF
--- a/commands/variables.go
+++ b/commands/variables.go
@@ -28,7 +28,7 @@ func SetVar(variables []string, settings *models.Settings) {
 
 	envVarsMap := make(map[string]string, len(variables))
 	for _, envVar := range variables {
-		pieces := strings.Split(envVar, "=")
+		pieces := strings.SplitN(envVar, "=", 2)
 		if len(pieces) != 2 {
 			fmt.Printf("Invalid variable format. Expected <key>=<value> but got %s\n", envVar)
 			os.Exit(1)


### PR DESCRIPTION
Fix for #7:

Limit the string split to split only at the first occurrence of "=". Environment variable values containing "=" characters will not be split. And will be added correctly to the service. 