### PR TITLE
Improved the logs command

### DIFF
--- a/.goxc.json
+++ b/.goxc.json
@@ -10,7 +10,7 @@
 	],
 	"BuildConstraints": "linux windows darwin",
 	"ResourcesExclude": "README*",
-	"PackageVersion": "2.1.5",
+	"PackageVersion": "2.1.6",
 	"TaskSettings": {
 		"publish-github": {
 			"body": "Catalyze CLI",

--- a/.goxc.json
+++ b/.goxc.json
@@ -1,5 +1,6 @@
 {
 	"ArtifactsDest": "builds/",
+	"OutPath": "{{.Dest}}{{.PS}}{{.Version}}{{.PS}}{{.Os}}-{{.Arch}}{{.PS}}{{.ExeName}}{{.Ext}}",
 	"Tasks": [
 		"default",
 		"publish-github"

--- a/Docs.md
+++ b/Docs.md
@@ -384,7 +384,7 @@ Usage: catalyze logs [QUERY] [(-f | -t)] [--hours] [--minutes] [--seconds]
 Show the logs in your terminal streamed from your logging dashboard
 
 Arguments:
-  QUERY="app*"   The query to send to your logging dashboard's elastic search (regex is supported)
+  QUERY="*"    The query to send to your logging dashboard's elastic search (regex is supported)
 
 Options:
   -f, --follow=false   Tail/follow the logs (Equivalent to -t)
@@ -398,6 +398,12 @@ Options:
 
 ```
 catalyze logs -f --hours=6 --minutes=30
+```
+
+The `logs` command, by default, prints out all application logs. You can filter your logs further by using the QUERY argument. This performs a wildcard search on the `message` field in your elastic search instance. Giving the value `sql*` is analogous to entering `message:sql*` in the elastic search text box. Here is a sample command using the QUERY argument
+
+```
+catalyze logs "sql*" -f --seconds=30
 ```
 
 ## <a id="logout"></a> logout

--- a/README.md
+++ b/README.md
@@ -12,25 +12,25 @@ Once downloaded, the CLI will automatically update itself when a new version bec
 
 **PLEASE NOTE** You **must** put the CLI binary in a location for which you have write permissions. Without write permissions, the CLI will not automatically update and you will have to update manually by visiting the github repo and downloading the latest binary.
 
-## Version 2.1.5
+## Version 2.1.6
 
 For all 64 bit users, choose the `amd64` version of your OS. For all 32 bit users, choose the `386` version of your OS.
 
 ### Darwin (Apple Mac)
 
- * [catalyze\_2.1.5\_darwin\_386.zip](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_darwin_386.zip)
- * [catalyze\_2.1.5\_darwin\_amd64.zip](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_darwin_amd64.zip)
+ * [catalyze\_2.1.6\_darwin\_386.zip](https://github.com/catalyzeio/cli/releases/download/2.1.6/catalyze_2.1.6_darwin_386.zip)
+ * [catalyze\_2.1.6\_darwin\_amd64.zip](https://github.com/catalyzeio/cli/releases/download/2.1.6/catalyze_2.1.6_darwin_amd64.zip)
 
 ### Linux
 
- * [catalyze\_2.1.5\_amd64.deb](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_amd64.deb)
- * [catalyze\_2.1.5\_armhf.deb](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_armhf.deb)
- * [catalyze\_2.1.5\_i386.deb](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_i386.deb)
- * [catalyze\_2.1.5\_linux\_386.tar.gz](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_linux_386.tar.gz)
- * [catalyze\_2.1.5\_linux\_amd64.tar.gz](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_linux_amd64.tar.gz)
- * [catalyze\_2.1.5\_linux\_arm.tar.gz](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_linux_arm.tar.gz)
+ * [catalyze\_2.1.6\_amd64.deb](https://github.com/catalyzeio/cli/releases/download/2.1.6/catalyze_2.1.6_amd64.deb)
+ * [catalyze\_2.1.6\_armhf.deb](https://github.com/catalyzeio/cli/releases/download/2.1.6/catalyze_2.1.6_armhf.deb)
+ * [catalyze\_2.1.6\_i386.deb](https://github.com/catalyzeio/cli/releases/download/2.1.6/catalyze_2.1.6_i386.deb)
+ * [catalyze\_2.1.6\_linux\_386.tar.gz](https://github.com/catalyzeio/cli/releases/download/2.1.6/catalyze_2.1.6_linux_386.tar.gz)
+ * [catalyze\_2.1.6\_linux\_amd64.tar.gz](https://github.com/catalyzeio/cli/releases/download/2.1.6/catalyze_2.1.6_linux_amd64.tar.gz)
+ * [catalyze\_2.1.6\_linux\_arm.tar.gz](https://github.com/catalyzeio/cli/releases/download/2.1.6/catalyze_2.1.6_linux_arm.tar.gz)
 
 ### MS Windows
 
- * [catalyze\_2.1.5\_windows\_386.zip](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_windows_386.zip)
- * [catalyze\_2.1.5\_windows\_amd64.zip](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_windows_amd64.zip)
+ * [catalyze\_2.1.6\_windows\_386.zip](https://github.com/catalyzeio/cli/releases/download/2.1.6/catalyze_2.1.6_windows_386.zip)
+ * [catalyze\_2.1.6\_windows\_amd64.zip](https://github.com/catalyzeio/cli/releases/download/2.1.6/catalyze_2.1.6_windows_amd64.zip)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Once downloaded, the CLI will automatically update itself when a new version bec
 
 ## Version 2.1.5
 
+For all 64 bit users, choose the `amd64` version of your OS. For all 32 bit users, choose the `386` version of your OS.
+
 ### Darwin (Apple Mac)
 
  * [catalyze\_2.1.5\_darwin\_386.zip](https://github.com/catalyzeio/cli/releases/download/2.1.5/catalyze_2.1.5_darwin_386.zip)

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -44,7 +44,7 @@ func Logs(queryString string, tail bool, hours int, minutes int, seconds int, se
 	}
 	appLogsIdentifier := "source"
 	appLogsValue := "app"
-	if strings.HasPrefix(domain, "pod01") {
+	if strings.HasPrefix(domain, "pod01") || strings.HasPrefix(domain, "csb01") {
 		appLogsIdentifier = "syslog_program"
 		appLogsValue = "supervisord"
 	}

--- a/commands/metrics.go
+++ b/commands/metrics.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/catalyzeio/catalyze/helpers"
 	"github.com/catalyzeio/catalyze/models"
-	ui "github.com/gizak/termui"
+	ui "gopkg.in/gizak/termui.v1"
 )
 
 // Transformer outlines an interface that takes in metrics data and transforms

--- a/config/constants.go
+++ b/config/constants.go
@@ -1,7 +1,7 @@
 package config
 
 // current cli version
-const VERSION = "2.1.5"
+const VERSION = "2.1.6"
 
 // alternate BaaS URL
 const BaasHost = "https://api.catalyze.io"

--- a/config/settings.go
+++ b/config/settings.go
@@ -17,8 +17,20 @@ const SettingsFile = ".catalyze"
 // LocalSettingsPath stores a breadcrumb in a local git repo with an env name
 const LocalSettingsFile = "catalyze-config.json"
 
+// SettingsRetriever defines an interface for a class responsible for generating
+// a settings object used for most commands in the CLI. Some examples might be
+// for retrieving settings based on the settings file or generating a settings
+// object based on a directly entered environment ID and service ID.
+type SettingsRetriever interface {
+	GetSettings(bool, bool, string, string, string, string, string, string) *models.Settings
+}
+
+// FileSettingsRetriever reads in data from the SettingsFile and generates a
+// settings object.
+type FileSettingsRetriever struct{}
+
 // GetSettings returns a Settings object for the current context
-func GetSettings(required bool, promptForEnv bool, envName string, baasHost string, paasHost string, username string, password string) *models.Settings {
+func (s FileSettingsRetriever) GetSettings(required bool, promptForEnv bool, envName string, svcName string, baasHost string, paasHost string, username string, password string) *models.Settings {
 	HomeDir, err := homedir.Dir()
 	if err != nil {
 		fmt.Println(err.Error())

--- a/models/models.go
+++ b/models/models.go
@@ -221,37 +221,6 @@ type CPUData struct {
 	Load  *MinMaxAvg `json:"load"`
 }
 
-// LogQuery holds data for querying Kibana's elastic search
-type LogQuery struct {
-	Fields []string     `json:"fields"`
-	Query  *Query       `json:"query"`
-	Filter *FilterRange `json:"filter"`
-	Sort   *LogSort     `json:"sort"`
-	From   int          `json:"from"`
-	Size   int          `json:"size"`
-}
-
-// LogSort tells the LogQuery how to sort the results
-type LogSort struct {
-	Timestamp map[string]string `json:"@timestamp"`
-	Message   map[string]string `json:"message"`
-}
-
-// Query holds query terms
-type Query struct {
-	Wildcard map[string]string `json:"wildcard"`
-}
-
-// FilterRange holds query filter range
-type FilterRange struct {
-	Range *RangeTimestamp `json:"range"`
-}
-
-// RangeTimestamp holds range timestamps
-type RangeTimestamp struct {
-	Timestamp map[string]string `json:"@timestamp"`
-}
-
 // Logs hold the log values from a successful LogQuery
 type Logs struct {
 	Hits *Hits `json:"hits"`


### PR DESCRIPTION
The logs command is now more intuitive to use with both AWS and RAX environments. All app logs are returned by default and you can further filter those logs by a wildcard search on the message field.