### PR TITLE
URL Encode Names

### DIFF
--- a/commands/certs/create.go
+++ b/commands/certs/create.go
@@ -5,15 +5,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/catalyzeio/cli/commands/services"
 	"github.com/catalyzeio/cli/commands/ssl"
+	"github.com/catalyzeio/cli/config"
 	"github.com/catalyzeio/cli/lib/httpclient"
 	"github.com/catalyzeio/cli/models"
 )
 
 func CmdCreate(hostname, pubKeyPath, privKeyPath string, selfSigned, resolve bool, ic ICerts, is services.IServices, issl ssl.ISSL) error {
+	if strings.ContainsAny(hostname, config.InvalidChars) {
+		return fmt.Errorf("Invalid cert hostname. Hostnames must not contain the following characters: %s", config.InvalidChars)
+	}
 	if _, err := os.Stat(pubKeyPath); os.IsNotExist(err) {
 		return fmt.Errorf("A cert does not exist at path '%s'", pubKeyPath)
 	}

--- a/commands/certs/rm.go
+++ b/commands/certs/rm.go
@@ -2,13 +2,18 @@ package certs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/catalyzeio/cli/commands/services"
+	"github.com/catalyzeio/cli/config"
 	"github.com/catalyzeio/cli/lib/httpclient"
 )
 
 func CmdRm(hostname string, ic ICerts, is services.IServices) error {
+	if strings.ContainsAny(hostname, config.InvalidChars) {
+		return fmt.Errorf("Invalid cert hostname. Hostnames must not contain the following characters: %s", config.InvalidChars)
+	}
 	service, err := is.RetrieveByLabel("service_proxy")
 	if err != nil {
 		return err

--- a/commands/certs/update.go
+++ b/commands/certs/update.go
@@ -5,15 +5,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/catalyzeio/cli/commands/services"
 	"github.com/catalyzeio/cli/commands/ssl"
+	"github.com/catalyzeio/cli/config"
 	"github.com/catalyzeio/cli/lib/httpclient"
 	"github.com/catalyzeio/cli/models"
 )
 
 func CmdUpdate(hostname, pubKeyPath, privKeyPath string, selfSigned, resolve bool, ic ICerts, is services.IServices, issl ssl.ISSL) error {
+	if strings.ContainsAny(hostname, config.InvalidChars) {
+		return fmt.Errorf("Invalid cert hostname. Hostnames must not contain the following characters: %s", config.InvalidChars)
+	}
 	if _, err := os.Stat(pubKeyPath); os.IsNotExist(err) {
 		return fmt.Errorf("A cert does not exist at path '%s'", pubKeyPath)
 	}

--- a/commands/deploykeys/add.go
+++ b/commands/deploykeys/add.go
@@ -5,15 +5,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"golang.org/x/crypto/ssh"
 
 	"github.com/catalyzeio/cli/commands/services"
+	"github.com/catalyzeio/cli/config"
 	"github.com/catalyzeio/cli/lib/httpclient"
 	"github.com/catalyzeio/cli/models"
 )
 
 func CmdAdd(name, keyPath, svcName string, id IDeployKeys, is services.IServices) error {
+	if strings.ContainsAny(name, config.InvalidChars) {
+		return fmt.Errorf("Invalid SSH key name. Names must not contain the following characters: %s", config.InvalidChars)
+	}
 	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 		return fmt.Errorf("A file does not exist at path '%s'", keyPath)
 	}

--- a/commands/deploykeys/rm.go
+++ b/commands/deploykeys/rm.go
@@ -2,12 +2,17 @@ package deploykeys
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/catalyzeio/cli/commands/services"
+	"github.com/catalyzeio/cli/config"
 	"github.com/catalyzeio/cli/lib/httpclient"
 )
 
 func CmdRm(name, svcName string, id IDeployKeys, is services.IServices) error {
+	if strings.ContainsAny(name, config.InvalidChars) {
+		return fmt.Errorf("Invalid SSH key name. Names must not contain the following characters: %s", config.InvalidChars)
+	}
 	service, err := is.RetrieveByLabel(svcName)
 	if err != nil {
 		return err

--- a/commands/keys/add.go
+++ b/commands/keys/add.go
@@ -4,17 +4,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"golang.org/x/crypto/ssh"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/catalyzeio/cli/commands/deploykeys"
+	"github.com/catalyzeio/cli/config"
 	"github.com/catalyzeio/cli/lib/httpclient"
 	"github.com/catalyzeio/cli/models"
 	"github.com/mitchellh/go-homedir"
 )
 
 func CmdAdd(name, path string, ik IKeys, id deploykeys.IDeployKeys) error {
+	if strings.ContainsAny(name, config.InvalidChars) {
+		return fmt.Errorf("Invalid key name. Names must not contain the following characters: %s", config.InvalidChars)
+	}
 	fullPath, err := homedir.Expand(path)
 	if err != nil {
 		return err

--- a/commands/keys/rm.go
+++ b/commands/keys/rm.go
@@ -2,12 +2,17 @@ package keys
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/catalyzeio/cli/config"
 	"github.com/catalyzeio/cli/lib/httpclient"
 )
 
 func CmdRemove(name string, ik IKeys) error {
+	if strings.ContainsAny(name, config.InvalidChars) {
+		return fmt.Errorf("Invalid key name. Names must not contain the following characters: %s", config.InvalidChars)
+	}
 	err := ik.Remove(name)
 	if err != nil {
 		return err

--- a/config/constants.go
+++ b/config/constants.go
@@ -46,6 +46,9 @@ const (
 	CatalyzeEnvironmentEnvVar = "CATALYZE_ENV"
 	// LogLevelEnvVar is the env variable used to override the logging level used
 	LogLevelEnvVar = "CATALYZE_LOG_LEVEL"
+
+	// InvalidChars is a string containing all invalid characters for naming
+	InvalidChars = "/?%"
 )
 
 // ErrEnvRequired is thrown when a command is run that requires an environment to be associated first


### PR DESCRIPTION
There were a few leftover places where names that would be put into a URL did not have any restrictions on allowed characters. This runs names through an invalid character list before accepting them. Invalid characters include `/`, `?`, and `%`. 