### PR TITLE
HTTP Redirect Headers

### DIFF
--- a/catalyze/catalyze.go
+++ b/catalyze/catalyze.go
@@ -3,7 +3,6 @@ package catalyze
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/catalyzeio/cli/commands/associate"
 	"github.com/catalyzeio/cli/commands/associated"
@@ -127,16 +126,7 @@ func Run() {
 
 	InitCLI(app, settings)
 
-	archString := "other"
-	switch runtime.GOARCH {
-	case "386":
-		archString = "32-bit"
-	case "amd64":
-		archString = "64-bit"
-	case "arm":
-		archString = "arm"
-	}
-	versionString := fmt.Sprintf("version %s %s", config.VERSION, archString)
+	versionString := fmt.Sprintf("version %s %s", config.VERSION, config.ArchString())
 	logrus.Debugln(versionString)
 	app.Version("v version", versionString)
 	app.Command("version", "Output the version and quit", func(cmd *cli.Cmd) {

--- a/commands/certs/create.go
+++ b/commands/certs/create.go
@@ -67,7 +67,7 @@ func (c *SCerts) Create(hostname, pubKey, privKey, svcID string) error {
 	if err != nil {
 		return err
 	}
-	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod)
+	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod, c.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(b, fmt.Sprintf("%s%s/environments/%s/services/%s/certs", c.Settings.PaasHost, c.Settings.PaasHostVersion, c.Settings.EnvironmentID, svcID), headers)
 	if err != nil {
 		return err

--- a/commands/certs/list.go
+++ b/commands/certs/list.go
@@ -30,7 +30,7 @@ func CmdList(ic ICerts, is services.IServices) error {
 }
 
 func (c *SCerts) List(svcID string) (*[]models.Cert, error) {
-	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod)
+	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod, c.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/certs", c.Settings.PaasHost, c.Settings.PaasHostVersion, c.Settings.EnvironmentID, svcID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/certs/rm.go
+++ b/commands/certs/rm.go
@@ -22,7 +22,7 @@ func CmdRm(hostname string, ic ICerts, is services.IServices) error {
 }
 
 func (c *SCerts) Rm(hostname, svcID string) error {
-	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod)
+	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod, c.Settings.UsersID)
 	resp, statusCode, err := httpclient.Delete(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/certs/%s", c.Settings.PaasHost, c.Settings.PaasHostVersion, c.Settings.EnvironmentID, svcID, hostname), headers)
 	if err != nil {
 		return err

--- a/commands/certs/update.go
+++ b/commands/certs/update.go
@@ -67,7 +67,7 @@ func (c *SCerts) Update(hostname, pubKey, privKey, svcID string) error {
 	if err != nil {
 		return err
 	}
-	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod)
+	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod, c.Settings.UsersID)
 	resp, statusCode, err := httpclient.Put(b, fmt.Sprintf("%s%s/environments/%s/services/%s/certs/%s", c.Settings.PaasHost, c.Settings.PaasHostVersion, c.Settings.EnvironmentID, svcID, hostname), headers)
 	if err != nil {
 		return err

--- a/commands/console/console.go
+++ b/commands/console/console.go
@@ -112,7 +112,7 @@ func (c *SConsole) Request(command string, service *models.Service) (*models.Job
 	if err != nil {
 		return nil, err
 	}
-	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod)
+	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod, c.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(b, fmt.Sprintf("%s%s/environments/%s/services/%s/console", c.Settings.PaasHost, c.Settings.PaasHostVersion, c.Settings.EnvironmentID, service.ID), headers)
 	if err != nil {
 		return nil, err
@@ -126,7 +126,7 @@ func (c *SConsole) Request(command string, service *models.Service) (*models.Job
 }
 
 func (c *SConsole) RetrieveTokens(jobID string, service *models.Service) (*models.ConsoleCredentials, error) {
-	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod)
+	headers := httpclient.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod, c.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/jobs/%s/console-token", c.Settings.PaasHost, c.Settings.PaasHostVersion, c.Settings.EnvironmentID, service.ID, jobID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/db/backup.go
+++ b/commands/db/backup.go
@@ -45,7 +45,7 @@ func CmdBackup(databaseName string, skipPoll bool, id IDb, is services.IServices
 
 // Backup creates a new backup
 func (d *SDb) Backup(service *models.Service) (*models.Job, error) {
-	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod)
+	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod, d.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/backup", d.Settings.PaasHost, d.Settings.PaasHostVersion, d.Settings.EnvironmentID, service.ID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/db/download.go
+++ b/commands/db/download.go
@@ -82,7 +82,7 @@ func (d *SDb) Download(backupID, filePath string, service *models.Service) error
 }
 
 func (d *SDb) TempDownloadURL(jobID string, service *models.Service) (*models.TempURL, error) {
-	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod)
+	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod, d.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/backup-url/%s", d.Settings.PaasHost, d.Settings.PaasHostVersion, d.Settings.EnvironmentID, service.ID, jobID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/db/import.go
+++ b/commands/db/import.go
@@ -107,7 +107,7 @@ func (d *SDb) Import(filePath, mongoCollection, mongoDatabase string, service *m
 		return nil, err
 	}
 
-	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod)
+	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod, d.Settings.UsersID)
 	resp, statusCode, err := httpclient.PutFile(encrFilePath, tempURL.URL, headers)
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func (d *SDb) Import(filePath, mongoCollection, mongoDatabase string, service *m
 }
 
 func (d *SDb) TempUploadURL(service *models.Service) (*models.TempURL, error) {
-	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod)
+	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod, d.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/restore-url", d.Settings.PaasHost, d.Settings.PaasHostVersion, d.Settings.EnvironmentID, service.ID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/db/list.go
+++ b/commands/db/list.go
@@ -53,7 +53,7 @@ func (jobs SortedJobs) Less(i, j int) bool {
 
 // List lists the created backups for the service sorted from oldest to newest
 func (d *SDb) List(page, pageSize int, service *models.Service) (*[]models.Job, error) {
-	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod)
+	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod, d.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/jobs?type=backup&pageNumber=%d&pageSize=%d", d.Settings.PaasHost, d.Settings.PaasHostVersion, d.Settings.EnvironmentID, service.ID, page, pageSize), headers)
 	if err != nil {
 		return nil, err

--- a/commands/db/logs.go
+++ b/commands/db/logs.go
@@ -84,7 +84,7 @@ func (d *SDb) DumpLogs(taskType string, job *models.Job, service *models.Service
 }
 
 func (d *SDb) TempLogsURL(jobID string, serviceID string) (*models.TempURL, error) {
-	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod)
+	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod, d.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/backup-restore-logs-url/%s", d.Settings.PaasHost, d.Settings.PaasHostVersion, d.Settings.EnvironmentID, serviceID, jobID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/deploykeys/add.go
+++ b/commands/deploykeys/add.go
@@ -50,7 +50,7 @@ func (d *SDeployKeys) Add(name, keyType, key, svcID string) error {
 	if err != nil {
 		return err
 	}
-	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod)
+	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod, d.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(b, fmt.Sprintf("%s%s/environments/%s/services/%s/ssh_keys", d.Settings.PaasHost, d.Settings.PaasHostVersion, d.Settings.EnvironmentID, svcID), headers)
 	if err != nil {
 		return err

--- a/commands/deploykeys/list.go
+++ b/commands/deploykeys/list.go
@@ -67,7 +67,7 @@ func CmdList(svcName string, id IDeployKeys, is services.IServices) error {
 }
 
 func (d *SDeployKeys) List(svcID string) (*[]models.DeployKey, error) {
-	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod)
+	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod, d.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/ssh_keys", d.Settings.PaasHost, d.Settings.PaasHostVersion, d.Settings.EnvironmentID, svcID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/deploykeys/rm.go
+++ b/commands/deploykeys/rm.go
@@ -22,7 +22,7 @@ func CmdRm(name, svcName string, id IDeployKeys, is services.IServices) error {
 }
 
 func (d *SDeployKeys) Rm(name, keyType, svcID string) error {
-	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod)
+	headers := httpclient.GetHeaders(d.Settings.SessionToken, d.Settings.Version, d.Settings.Pod, d.Settings.UsersID)
 	resp, statusCode, err := httpclient.Delete(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/ssh_keys/%s/type/%s", d.Settings.PaasHost, d.Settings.PaasHostVersion, d.Settings.EnvironmentID, svcID, name, keyType), headers)
 	if err != nil {
 		return err

--- a/commands/environments/environments.go
+++ b/commands/environments/environments.go
@@ -26,7 +26,7 @@ func CmdEnvironments(environments IEnvironments) error {
 func (e *SEnvironments) List() (*[]models.Environment, error) {
 	var allEnvs []models.Environment
 	for _, pod := range *e.Settings.Pods {
-		headers := httpclient.GetHeaders(e.Settings.SessionToken, e.Settings.Version, pod.Name)
+		headers := httpclient.GetHeaders(e.Settings.SessionToken, e.Settings.Version, pod.Name, e.Settings.UsersID)
 		resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments", e.Settings.PaasHost, e.Settings.PaasHostVersion), headers)
 		if err != nil {
 			return nil, err
@@ -45,7 +45,7 @@ func (e *SEnvironments) List() (*[]models.Environment, error) {
 }
 
 func (e *SEnvironments) Retrieve(envID string) (*models.Environment, error) {
-	headers := httpclient.GetHeaders(e.Settings.SessionToken, e.Settings.Version, e.Settings.Pod)
+	headers := httpclient.GetHeaders(e.Settings.SessionToken, e.Settings.Version, e.Settings.Pod, e.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s", e.Settings.PaasHost, e.Settings.PaasHostVersion, envID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/files/create.go
+++ b/commands/files/create.go
@@ -26,7 +26,7 @@ func (f *SFiles) Create(svcID, filePath, name, mode string) (*models.ServiceFile
 	if err != nil {
 		return nil, err
 	}
-	headers := httpclient.GetHeaders(f.Settings.SessionToken, f.Settings.Version, f.Settings.Pod)
+	headers := httpclient.GetHeaders(f.Settings.SessionToken, f.Settings.Version, f.Settings.Pod, f.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(body, fmt.Sprintf("%s%s/environments/%s/services/%s/files", f.Settings.PaasHost, f.Settings.PaasHostVersion, f.Settings.EnvironmentID, svcID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/files/download.go
+++ b/commands/files/download.go
@@ -48,7 +48,7 @@ func (f *SFiles) Retrieve(fileName string, svcID string) (*models.ServiceFile, e
 	}
 	for _, ff := range *files {
 		if ff.Name == fileName {
-			headers := httpclient.GetHeaders(f.Settings.SessionToken, f.Settings.Version, f.Settings.Pod)
+			headers := httpclient.GetHeaders(f.Settings.SessionToken, f.Settings.Version, f.Settings.Pod, f.Settings.UsersID)
 			resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/files/%d", f.Settings.PaasHost, f.Settings.PaasHostVersion, f.Settings.EnvironmentID, svcID, ff.ID), headers)
 			if err != nil {
 				return nil, err

--- a/commands/files/list.go
+++ b/commands/files/list.go
@@ -60,7 +60,7 @@ func fileModeToRWXString(perms uint64) string {
 }
 
 func (f *SFiles) List(svcID string) (*[]models.ServiceFile, error) {
-	headers := httpclient.GetHeaders(f.Settings.SessionToken, f.Settings.Version, f.Settings.Pod)
+	headers := httpclient.GetHeaders(f.Settings.SessionToken, f.Settings.Version, f.Settings.Pod, f.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/files", f.Settings.PaasHost, f.Settings.PaasHostVersion, f.Settings.EnvironmentID, svcID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/invites/accept.go
+++ b/commands/invites/accept.go
@@ -29,7 +29,7 @@ func CmdAccept(inviteCode string, ii IInvites, ia auth.IAuth, ip prompts.IPrompt
 }
 
 func (i *SInvites) Accept(inviteCode string) (string, error) {
-	headers := httpclient.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod)
+	headers := httpclient.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod, i.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(nil, fmt.Sprintf("%s%s/orgs/accept-invite/%s", i.Settings.AuthHost, i.Settings.AuthHostVersion, inviteCode), headers)
 	if err != nil {
 		return "", err

--- a/commands/invites/list.go
+++ b/commands/invites/list.go
@@ -26,7 +26,7 @@ func CmdList(envName string, ii IInvites) error {
 
 // List lists all pending invites for a given org.
 func (i *SInvites) List() (*[]models.Invite, error) {
-	headers := httpclient.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod)
+	headers := httpclient.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod, i.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/orgs/%s/invites", i.Settings.AuthHost, i.Settings.AuthHostVersion, i.Settings.OrgID), headers)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (i *SInvites) List() (*[]models.Invite, error) {
 
 // ListRoles lists all available roles
 func (i *SInvites) ListRoles() (*[]models.Role, error) {
-	headers := httpclient.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod)
+	headers := httpclient.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod, i.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/orgs/roles", i.Settings.AuthHost, i.Settings.AuthHostVersion), headers)
 	if err != nil {
 		return nil, err

--- a/commands/invites/rm.go
+++ b/commands/invites/rm.go
@@ -19,7 +19,7 @@ func CmdRm(inviteID string, ii IInvites) error {
 // Rm deletes an invite sent to a user. This invite must not already be
 // accepted.
 func (i *SInvites) Rm(inviteID string) error {
-	headers := httpclient.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod)
+	headers := httpclient.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod, i.Settings.UsersID)
 	resp, statusCode, err := httpclient.Delete(nil, fmt.Sprintf("%s%s/orgs/%s/invites/%s", i.Settings.AuthHost, i.Settings.AuthHostVersion, i.Settings.OrgID, inviteID), headers)
 	if err != nil {
 		return err

--- a/commands/invites/send.go
+++ b/commands/invites/send.go
@@ -48,7 +48,7 @@ func (i *SInvites) Send(email string, role int) error {
 	if err != nil {
 		return err
 	}
-	headers := httpclient.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod)
+	headers := httpclient.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod, i.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(b, fmt.Sprintf("%s%s/orgs/%s/invites", i.Settings.AuthHost, i.Settings.AuthHostVersion, i.Settings.OrgID), headers)
 	if err != nil {
 		return err

--- a/commands/keys/add.go
+++ b/commands/keys/add.go
@@ -48,7 +48,7 @@ func (k *SKeys) Add(name, publicKey string) error {
 	if err != nil {
 		return err
 	}
-	headers := httpclient.GetHeaders(k.Settings.SessionToken, k.Settings.Version, k.Settings.Pod)
+	headers := httpclient.GetHeaders(k.Settings.SessionToken, k.Settings.Version, k.Settings.Pod, k.Settings.UsersID)
 	resp, status, err := httpclient.Post(body, fmt.Sprintf("%s%s/keys", k.Settings.AuthHost, k.Settings.AuthHostVersion), headers)
 	if err != nil {
 		return err

--- a/commands/keys/list.go
+++ b/commands/keys/list.go
@@ -53,7 +53,7 @@ func CmdList(ik IKeys, id deploykeys.IDeployKeys) error {
 }
 
 func (k *SKeys) List() (*[]models.UserKey, error) {
-	headers := httpclient.GetHeaders(k.Settings.SessionToken, k.Settings.Version, k.Settings.Pod)
+	headers := httpclient.GetHeaders(k.Settings.SessionToken, k.Settings.Version, k.Settings.Pod, k.Settings.UsersID)
 	resp, status, err := httpclient.Get(nil, fmt.Sprintf("%s%s/keys", k.Settings.AuthHost, k.Settings.AuthHostVersion), headers)
 	if err != nil {
 		return nil, err

--- a/commands/keys/rm.go
+++ b/commands/keys/rm.go
@@ -17,7 +17,7 @@ func CmdRemove(name string, ik IKeys) error {
 }
 
 func (k *SKeys) Remove(name string) error {
-	headers := httpclient.GetHeaders(k.Settings.SessionToken, k.Settings.Version, k.Settings.Pod)
+	headers := httpclient.GetHeaders(k.Settings.SessionToken, k.Settings.Version, k.Settings.Pod, k.Settings.UsersID)
 	resp, status, err := httpclient.Delete(nil, fmt.Sprintf("%s%s/keys/%s", k.Settings.AuthHost, k.Settings.AuthHostVersion, name), headers)
 	if err != nil {
 		return err

--- a/commands/metrics/metrics.go
+++ b/commands/metrics/metrics.go
@@ -180,7 +180,7 @@ func metricsTypeToString(metricType MetricType) string {
 // RetrieveEnvironmentMetrics retrieves metrics data for all services in
 // the associated environment.
 func (m *SMetrics) RetrieveEnvironmentMetrics(mins int) (*[]models.Metrics, error) {
-	headers := httpclient.GetHeaders(m.Settings.SessionToken, m.Settings.Version, m.Settings.Pod)
+	headers := httpclient.GetHeaders(m.Settings.SessionToken, m.Settings.Version, m.Settings.Pod, m.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/metrics?time=%dm", m.Settings.PaasHost, m.Settings.PaasHostVersion, m.Settings.EnvironmentID, mins), headers)
 	if err != nil {
 		return nil, err
@@ -195,7 +195,7 @@ func (m *SMetrics) RetrieveEnvironmentMetrics(mins int) (*[]models.Metrics, erro
 
 // RetrieveServiceMetrics retrieves metrics data for the given service.
 func (m *SMetrics) RetrieveServiceMetrics(mins int, svcID string) (*models.Metrics, error) {
-	headers := httpclient.GetHeaders(m.Settings.SessionToken, m.Settings.Version, m.Settings.Pod)
+	headers := httpclient.GetHeaders(m.Settings.SessionToken, m.Settings.Version, m.Settings.Pod, m.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/metrics?time=%dm", m.Settings.PaasHost, m.Settings.PaasHostVersion, m.Settings.EnvironmentID, svcID, mins), headers)
 	if err != nil {
 		return nil, err

--- a/commands/rake/rake.go
+++ b/commands/rake/rake.go
@@ -28,7 +28,7 @@ func (r *SRake) Run(taskName string) error {
 	if err != nil {
 		return err
 	}
-	headers := httpclient.GetHeaders(r.Settings.SessionToken, r.Settings.Version, r.Settings.Pod)
+	headers := httpclient.GetHeaders(r.Settings.SessionToken, r.Settings.Version, r.Settings.Pod, r.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(b, fmt.Sprintf("%s%s/environments/%s/services/%s/rake", r.Settings.PaasHost, r.Settings.PaasHostVersion, r.Settings.EnvironmentID, r.Settings.ServiceID), headers)
 	if err != nil {
 		return err

--- a/commands/redeploy/redeploy.go
+++ b/commands/redeploy/redeploy.go
@@ -30,7 +30,7 @@ func CmdRedeploy(svcName string, ir IRedeploy, is services.IServices) error {
 // first. The same version of the currently running service is deployed with
 // no changes.
 func (r *SRedeploy) Redeploy(service *models.Service) error {
-	headers := httpclient.GetHeaders(r.Settings.SessionToken, r.Settings.Version, r.Settings.Pod)
+	headers := httpclient.GetHeaders(r.Settings.SessionToken, r.Settings.Version, r.Settings.Pod, r.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/deploy?redeploy=true", r.Settings.PaasHost, r.Settings.PaasHostVersion, r.Settings.EnvironmentID, service.ID), headers)
 	if err != nil {
 		return err

--- a/commands/services/services.go
+++ b/commands/services/services.go
@@ -36,7 +36,7 @@ func (s *SServices) List() (*[]models.Service, error) {
 }
 
 func (s *SServices) ListByEnvID(envID, podID string) (*[]models.Service, error) {
-	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, podID)
+	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, podID, s.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services", s.Settings.PaasHost, s.Settings.PaasHostVersion, envID), headers)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func (s *SServices) ListByEnvID(envID, podID string) (*[]models.Service, error) 
 }
 
 func (s *SServices) Retrieve(svcID string) (*models.Service, error) {
-	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, s.Settings.Pod)
+	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, s.Settings.Pod, s.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s", s.Settings.PaasHost, s.Settings.PaasHostVersion, s.Settings.EnvironmentID, s.Settings.ServiceID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/sites/create.go
+++ b/commands/sites/create.go
@@ -42,7 +42,7 @@ func (s *SSites) Create(name, cert, upstreamServiceID, svcID string) (*models.Si
 	if err != nil {
 		return nil, err
 	}
-	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, s.Settings.Pod)
+	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, s.Settings.Pod, s.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(b, fmt.Sprintf("%s%s/environments/%s/services/%s/sites", s.Settings.PaasHost, s.Settings.PaasHostVersion, s.Settings.EnvironmentID, svcID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/sites/list.go
+++ b/commands/sites/list.go
@@ -46,7 +46,7 @@ func CmdList(is ISites, iservices services.IServices) error {
 }
 
 func (s *SSites) List(svcID string) (*[]models.Site, error) {
-	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, s.Settings.Pod)
+	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, s.Settings.Pod, s.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/sites", s.Settings.PaasHost, s.Settings.PaasHostVersion, s.Settings.EnvironmentID, svcID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/sites/rm.go
+++ b/commands/sites/rm.go
@@ -36,7 +36,7 @@ func CmdRm(name string, is ISites, iservices services.IServices) error {
 }
 
 func (s *SSites) Rm(siteID int, svcID string) error {
-	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, s.Settings.Pod)
+	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, s.Settings.Pod, s.Settings.UsersID)
 	resp, statusCode, err := httpclient.Delete(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/sites/%d", s.Settings.PaasHost, s.Settings.PaasHostVersion, s.Settings.EnvironmentID, svcID, siteID), headers)
 	if err != nil {
 		return err

--- a/commands/sites/show.go
+++ b/commands/sites/show.go
@@ -41,7 +41,7 @@ func CmdShow(name string, is ISites, iservices services.IServices) error {
 }
 
 func (s *SSites) Retrieve(siteID int, svcID string) (*models.Site, error) {
-	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, s.Settings.Pod)
+	headers := httpclient.GetHeaders(s.Settings.SessionToken, s.Settings.Version, s.Settings.Pod, s.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/sites/%d", s.Settings.PaasHost, s.Settings.PaasHostVersion, s.Settings.EnvironmentID, svcID, siteID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/users/list.go
+++ b/commands/users/list.go
@@ -48,7 +48,7 @@ func CmdList(myUsersID string, iu IUsers, ii invites.IInvites) error {
 }
 
 func (u *SUsers) List() (*[]models.OrgUser, error) {
-	headers := httpclient.GetHeaders(u.Settings.SessionToken, u.Settings.Version, u.Settings.Pod)
+	headers := httpclient.GetHeaders(u.Settings.SessionToken, u.Settings.Version, u.Settings.Pod, u.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/orgs/%s/users", u.Settings.AuthHost, u.Settings.AuthHostVersion, u.Settings.OrgID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/users/rm.go
+++ b/commands/users/rm.go
@@ -32,7 +32,7 @@ func CmdRm(email string, iu IUsers) error {
 }
 
 func (u *SUsers) Rm(usersID string) error {
-	headers := httpclient.GetHeaders(u.Settings.SessionToken, u.Settings.Version, u.Settings.Pod)
+	headers := httpclient.GetHeaders(u.Settings.SessionToken, u.Settings.Version, u.Settings.Pod, u.Settings.UsersID)
 	resp, statusCode, err := httpclient.Delete(nil, fmt.Sprintf("%s%s/orgs/%s/users/%s", u.Settings.AuthHost, u.Settings.AuthHostVersion, u.Settings.OrgID, usersID), headers)
 	if err != nil {
 		return err

--- a/commands/vars/list.go
+++ b/commands/vars/list.go
@@ -26,7 +26,7 @@ func CmdList(iv IVars) error {
 
 // List lists all environment variables.
 func (v *SVars) List() (map[string]string, error) {
-	headers := httpclient.GetHeaders(v.Settings.SessionToken, v.Settings.Version, v.Settings.Pod)
+	headers := httpclient.GetHeaders(v.Settings.SessionToken, v.Settings.Version, v.Settings.Pod, v.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/env", v.Settings.PaasHost, v.Settings.PaasHostVersion, v.Settings.EnvironmentID, v.Settings.ServiceID), headers)
 	if err != nil {
 		return nil, err

--- a/commands/vars/set.go
+++ b/commands/vars/set.go
@@ -42,7 +42,7 @@ func (v *SVars) Set(envVarsMap map[string]string) error {
 	if err != nil {
 		return err
 	}
-	headers := httpclient.GetHeaders(v.Settings.SessionToken, v.Settings.Version, v.Settings.Pod)
+	headers := httpclient.GetHeaders(v.Settings.SessionToken, v.Settings.Version, v.Settings.Pod, v.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(b, fmt.Sprintf("%s%s/environments/%s/services/%s/env", v.Settings.PaasHost, v.Settings.PaasHostVersion, v.Settings.EnvironmentID, v.Settings.ServiceID), headers)
 	if err != nil {
 		return err

--- a/commands/vars/unset.go
+++ b/commands/vars/unset.go
@@ -20,7 +20,7 @@ func CmdUnset(key string, iv IVars) error {
 // will not take effect until the service is redeployed by pushing new code
 // or via `catalyze redeploy`.
 func (v *SVars) Unset(variable string) error {
-	headers := httpclient.GetHeaders(v.Settings.SessionToken, v.Settings.Version, v.Settings.Pod)
+	headers := httpclient.GetHeaders(v.Settings.SessionToken, v.Settings.Version, v.Settings.Pod, v.Settings.UsersID)
 	resp, statusCode, err := httpclient.Delete(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/env/%s", v.Settings.PaasHost, v.Settings.PaasHostVersion, v.Settings.EnvironmentID, v.Settings.ServiceID, variable), headers)
 	if err != nil {
 		return err

--- a/commands/worker/worker.go
+++ b/commands/worker/worker.go
@@ -28,7 +28,7 @@ func (w *SWorker) Start(target string) error {
 	if err != nil {
 		return err
 	}
-	headers := httpclient.GetHeaders(w.Settings.SessionToken, w.Settings.Version, w.Settings.Pod)
+	headers := httpclient.GetHeaders(w.Settings.SessionToken, w.Settings.Version, w.Settings.Pod, w.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(b, fmt.Sprintf("%s%s/environments/%s/services/%s/worker", w.Settings.PaasHost, w.Settings.PaasHostVersion, w.Settings.EnvironmentID, w.Settings.ServiceID), headers)
 	if err != nil {
 		return err

--- a/config/constants.go
+++ b/config/constants.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"runtime"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -50,3 +51,18 @@ const (
 
 // ErrEnvRequired is thrown when a command is run that requires an environment to be associated first
 var ErrEnvRequired = errors.New("No Catalyze environment has been associated. Run \"catalyze associate\" from a local git repo first")
+
+// ArchString translates the current architecture into an easier to read value.
+// amd64 becomes 64-bit, 386 becomes 32-bit, etc.
+func ArchString() string {
+	archString := "other"
+	switch runtime.GOARCH {
+	case "386":
+		archString = "32-bit"
+	case "amd64":
+		archString = "64-bit"
+	case "arm":
+		archString = "arm"
+	}
+	return archString
+}

--- a/lib/auth/signin.go
+++ b/lib/auth/signin.go
@@ -49,7 +49,7 @@ func (a *SAuth) signInWithCredentials() (*models.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	headers := httpclient.GetHeaders(a.Settings.SessionToken, a.Settings.Version, a.Settings.Pod)
+	headers := httpclient.GetHeaders(a.Settings.SessionToken, a.Settings.Version, a.Settings.Pod, a.Settings.UsersID)
 	resp, statusCode, err := httpclient.Post(b, fmt.Sprintf("%s%s/auth/signin", a.Settings.AuthHost, a.Settings.AuthHostVersion), headers)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (a *SAuth) signInWithKey() (*models.User, error) {
 	}
 	body.PublicKey = string(publicKey)
 
-	headers := httpclient.GetHeaders(a.Settings.SessionToken, a.Settings.Version, a.Settings.Pod)
+	headers := httpclient.GetHeaders(a.Settings.SessionToken, a.Settings.Version, a.Settings.Pod, a.Settings.UsersID)
 	message := fmt.Sprintf("%s&%s", headers["X-Request-Nonce"][0], headers["X-Request-Timestamp"][0])
 	hashedMessage := sha256.Sum256([]byte(message))
 	signature, err := privateKey.Sign(rand.Reader, hashedMessage[:], crypto.SHA256)
@@ -127,7 +127,7 @@ func (a *SAuth) signInWithKey() (*models.User, error) {
 
 // Signout signs out a user by their session token.
 func (a *SAuth) Signout() error {
-	headers := httpclient.GetHeaders(a.Settings.SessionToken, a.Settings.Version, a.Settings.Pod)
+	headers := httpclient.GetHeaders(a.Settings.SessionToken, a.Settings.Version, a.Settings.Pod, a.Settings.UsersID)
 	resp, statusCode, err := httpclient.Delete(nil, fmt.Sprintf("%s%s/auth/signout", a.Settings.AuthHost, a.Settings.AuthHostVersion), headers)
 	if err != nil {
 		return err
@@ -138,7 +138,7 @@ func (a *SAuth) Signout() error {
 // Verify verifies if a given session token is still valid or not. If it is
 // valid, the returned error will be nil.
 func (a *SAuth) Verify() (*models.User, error) {
-	headers := httpclient.GetHeaders(a.Settings.SessionToken, a.Settings.Version, a.Settings.Pod)
+	headers := httpclient.GetHeaders(a.Settings.SessionToken, a.Settings.Version, a.Settings.Pod, a.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/auth/verify", a.Settings.AuthHost, a.Settings.AuthHostVersion), headers)
 	if err != nil {
 		return nil, err

--- a/lib/httpclient/client.go
+++ b/lib/httpclient/client.go
@@ -20,7 +20,7 @@ import (
 	"github.com/catalyzeio/cli/models"
 )
 
-const defaultRedirectLimit = 30
+const defaultRedirectLimit = 10
 
 func getClient() *http.Client {
 	var tr = &http.Transport{

--- a/lib/jobs/delete.go
+++ b/lib/jobs/delete.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (j *SJobs) Delete(jobID, svcID string) error {
-	headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod)
+	headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod, j.Settings.UsersID)
 	resp, statusCode, err := httpclient.Delete(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/jobs/%s", j.Settings.PaasHost, j.Settings.PaasHostVersion, j.Settings.EnvironmentID, svcID, jobID), headers)
 	if err != nil {
 		return err

--- a/lib/jobs/list.go
+++ b/lib/jobs/list.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (j *SJobs) List(svcID string, page, pageSize int) (*[]models.Job, error) {
-	headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod)
+	headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod, j.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/jobs?pageNumber=%d&pageSize=%d", j.Settings.PaasHost, j.Settings.PaasHostVersion, j.Settings.EnvironmentID, svcID, page, pageSize), headers)
 	if err != nil {
 		return nil, err

--- a/lib/jobs/poll.go
+++ b/lib/jobs/poll.go
@@ -29,7 +29,7 @@ func (j *SJobs) PollForStatus(statuses []string, jobID, svcID string) (string, e
 poll:
 	for {
 		failed := false
-		headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod)
+		headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod, j.Settings.UsersID)
 		resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/jobs/%s", j.Settings.PaasHost, j.Settings.PaasHostVersion, j.Settings.EnvironmentID, svcID, jobID), headers)
 		if err != nil {
 			failed = true

--- a/lib/jobs/retrieve.go
+++ b/lib/jobs/retrieve.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (j *SJobs) Retrieve(jobID, svcID string, includeSpec bool) (*models.Job, error) {
-	headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod)
+	headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod, j.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/jobs/%s?spec=true", j.Settings.PaasHost, j.Settings.PaasHostVersion, j.Settings.EnvironmentID, svcID, jobID), headers)
 	if err != nil {
 		return nil, err
@@ -22,7 +22,7 @@ func (j *SJobs) Retrieve(jobID, svcID string, includeSpec bool) (*models.Job, er
 }
 
 func (j *SJobs) RetrieveByStatus(status string) (*[]models.Job, error) {
-	headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod)
+	headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod, j.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/jobs?status=%s", j.Settings.PaasHost, j.Settings.PaasHostVersion, j.Settings.EnvironmentID, j.Settings.ServiceID, status), headers)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func (j *SJobs) RetrieveByStatus(status string) (*[]models.Job, error) {
 }
 
 func (j *SJobs) RetrieveByType(jobType string, page, pageSize int) (*[]models.Job, error) {
-	headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod)
+	headers := httpclient.GetHeaders(j.Settings.SessionToken, j.Settings.Version, j.Settings.Pod, j.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/jobs?type=%s&pageNumber=%d&pageSize=%d", j.Settings.PaasHost, j.Settings.PaasHostVersion, j.Settings.EnvironmentID, j.Settings.ServiceID, jobType, page, pageSize), headers)
 	if err != nil {
 		return nil, err

--- a/lib/pods/list.go
+++ b/lib/pods/list.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (p *SPods) List() (*[]models.Pod, error) {
-	headers := httpclient.GetHeaders(p.Settings.SessionToken, p.Settings.Version, p.Settings.Pod)
+	headers := httpclient.GetHeaders(p.Settings.SessionToken, p.Settings.Version, p.Settings.Pod, p.Settings.UsersID)
 	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/pods", p.Settings.PaasHost, p.Settings.PaasHostVersion), headers)
 	if err != nil {
 		return nil, err

--- a/models/models.go
+++ b/models/models.go
@@ -124,14 +124,15 @@ type Service struct {
 	EnvVars map[string]string `json:"environmentVariables,omitempty"`
 	Source  string            `json:"source,omitempty"`
 	LBIP    string            `json:"load_balancer_ip,omitempty"`
+	Scale   int               `json:"scale,omitempty"`
 }
 
 // ServiceSize holds size information for a service
 type ServiceSize struct {
 	RAM      int    `json:"ram"`
 	Storage  int    `json:"storage"`
-	Behavior string `json:"behavior"`
-	Type     string `json:"type"`
+	Behavior string `json:"behavior,omitempty"`
+	Type     string `json:"type,omitempty"`
 	CPU      int    `json:"cpu"`
 }
 


### PR DESCRIPTION
Headers are now persisted to all http redirects resulting in a 301 from the original request. The net/http library automatically follows those, but did not add back in data from the original request. This must be a manual process. Also added the usersID and architecture to the `User-Agent` header.