### PR TITLE
use os.File.Stat instead of syscall.Stat for slightly better OS compatibility

### DIFF
--- a/commands/update/iswriteable_nonwindows.go
+++ b/commands/update/iswriteable_nonwindows.go
@@ -1,0 +1,52 @@
+// +build !windows
+
+package update
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/bugsnag/osext"
+)
+
+func verifyExeDirWriteable() error {
+	exe, err := osext.Executable()
+	if err != nil {
+		return exeGenericError()
+	}
+	exeDir := filepath.Dir(exe)
+	f, err := os.Open(exeDir)
+	if err != nil {
+		return exeGenericError()
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return exeGenericError()
+	}
+	usr, err := user.Current()
+	if err != nil {
+		return exeGenericError()
+	}
+	ownerID := strconv.FormatUint(uint64(info.Sys().(*syscall.Stat_t).Uid), 10)
+	groupID := strconv.FormatUint(uint64(info.Sys().(*syscall.Stat_t).Gid), 10)
+	// permissions are the 9 least significant bits
+	mode := uint32(info.Mode()) & uint32((1<<9)-1)
+	// Ex: 7   7   7
+	//    111 111 111
+	//         ^   ^
+	groupWriteAble := uint32(1 << 4)
+	globalWriteAble := uint32(1 << 1)
+	// if user doesn't own the directory, and the directory isn't globally writeable,
+	// and it is false that the directory is group writeable and the user is part of
+	// the group, then we can't update.
+	if ownerID != usr.Uid &&
+		(mode&globalWriteAble) != globalWriteAble &&
+		!((mode&groupWriteAble) == groupWriteAble && groupID == usr.Gid) {
+		return fmt.Errorf("Your CLI cannot update, because your user cannot directly write to the directory it is in, \"%s\". Run the update command as the owner of the directory, or do the update manually.", exeDir)
+	}
+	return nil
+}

--- a/commands/update/iswriteable_windows.go
+++ b/commands/update/iswriteable_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package update
+
+import (
+	"fmt"
+)
+
+func verifyExeDirWriteable() error {
+	return fmt.Errorf("This function is not intended to be called on Windows.")
+}

--- a/commands/update/update.go
+++ b/commands/update/update.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"fmt"
+	"os"
 	"os/user"
 	"path/filepath"
 	"runtime"
@@ -25,8 +26,11 @@ func CmdUpdate(iu IUpdate) error {
 			return exeGenericError()
 		}
 		exeDir := filepath.Dir(exe)
-		stat := syscall.Stat_t{}
-		err = syscall.Stat(exeDir, &stat)
+		f, err := os.Open(exeDir)
+		if err != nil {
+			return exeGenericError()
+		}
+		info, err := f.Stat()
 		if err != nil {
 			return exeGenericError()
 		}
@@ -34,10 +38,10 @@ func CmdUpdate(iu IUpdate) error {
 		if err != nil {
 			return exeGenericError()
 		}
-		ownerId := strconv.FormatUint(uint64(stat.Uid), 10)
-		groupId := strconv.FormatUint(uint64(stat.Gid), 10)
+		ownerId := strconv.FormatUint(uint64(info.Sys().(*syscall.Stat_t).Uid), 10)
+		groupId := strconv.FormatUint(uint64(info.Sys().(*syscall.Stat_t).Gid), 10)
 		// permissions are the 9 least significant bits
-		mode := stat.Mode & uint32((1<<9)-1)
+		mode := uint32(info.Mode()) & uint32((1<<9)-1)
 		// Ex: 7   7   7
 		//    111 111 111
 		//         ^   ^

--- a/commands/update/update.go
+++ b/commands/update/update.go
@@ -2,15 +2,10 @@ package update
 
 import (
 	"fmt"
-	"os"
-	"os/user"
-	"path/filepath"
 	"runtime"
-	"strconv"
-	"syscall"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/bugsnag/osext"
+
 	"github.com/catalyzeio/cli/lib/updater"
 )
 
@@ -21,40 +16,9 @@ func CmdUpdate(iu IUpdate) error {
 	}
 	// check if we can overwrite exe
 	if needsUpdate && (runtime.GOOS == "linux" || runtime.GOOS == "darwin") {
-		exe, err := osext.Executable()
+		err = verifyExeDirWriteable()
 		if err != nil {
-			return exeGenericError()
-		}
-		exeDir := filepath.Dir(exe)
-		f, err := os.Open(exeDir)
-		if err != nil {
-			return exeGenericError()
-		}
-		info, err := f.Stat()
-		if err != nil {
-			return exeGenericError()
-		}
-		usr, err := user.Current()
-		if err != nil {
-			return exeGenericError()
-		}
-		ownerId := strconv.FormatUint(uint64(info.Sys().(*syscall.Stat_t).Uid), 10)
-		groupId := strconv.FormatUint(uint64(info.Sys().(*syscall.Stat_t).Gid), 10)
-		// permissions are the 9 least significant bits
-		mode := uint32(info.Mode()) & uint32((1<<9)-1)
-		// Ex: 7   7   7
-		//    111 111 111
-		//         ^   ^
-		groupWriteAble := uint32(1 << 4)
-		globalWriteAble := uint32(1 << 1)
-		// if user doesn't own the directory, and the directory isn't globally writeable,
-		// and it is false that the directory is group writeable and the user is part of
-		// the group, then we can't update.
-		if ownerId != usr.Uid &&
-			(mode&globalWriteAble) != globalWriteAble &&
-			!((mode&groupWriteAble) == groupWriteAble && groupId == usr.Gid) {
-			return fmt.Errorf("Your CLI cannot update, because your user cannot directly write to the directory it is in, \"%s\". Run the update command as the owner of the directory, or do the update manually.", exeDir)
-
+			return err
 		}
 	}
 	logrus.Println("Checking for available updates...")


### PR DESCRIPTION
Without this, it does not compile on OSX at the moment (because `syscall.Stat_t.Mode` is `uint16` on OSX but a uint32 on linux).
