### PR TITLE
Notifications & error enhancements

### DIFF
--- a/commands/associate/associate.go
+++ b/commands/associate/associate.go
@@ -82,6 +82,7 @@ func CmdAssociate(envLabel, svcLabel, alias, remote string, defaultEnv bool, ia 
 		return err
 	}
 	logrus.Printf("Your git repository \"%s\" has been associated with code service \"%s\" and environment \"%s\"", remote, svcLabel, name)
+	logrus.Println("After associating to an environment, you need to add a cert with the \"catalyze certs create\" command if you have not done so already")
 	return nil
 }
 

--- a/commands/associate/associate.go
+++ b/commands/associate/associate.go
@@ -37,7 +37,7 @@ func CmdAssociate(envLabel, svcLabel, alias, remote string, defaultEnv bool, ia 
 		}
 	}
 	if e == nil {
-		return fmt.Errorf("No environment with label \"%s\" found", envLabel)
+		return fmt.Errorf("No environment with name \"%s\" found", envLabel)
 	}
 	if svcs == nil {
 		return fmt.Errorf("No services found for environment with name \"%s\"", envLabel)
@@ -55,7 +55,7 @@ func CmdAssociate(envLabel, svcLabel, alias, remote string, defaultEnv bool, ia 
 		}
 	}
 	if chosenService == nil {
-		return fmt.Errorf("No code service found with name '%s'. Code services found: %s", svcLabel, strings.Join(availableCodeServices, ", "))
+		return fmt.Errorf("No code service found with label '%s'. Code services found: %s", svcLabel, strings.Join(availableCodeServices, ", "))
 	}
 	remotes, err := ig.List()
 	if err != nil {

--- a/commands/certs/create.go
+++ b/commands/certs/create.go
@@ -59,6 +59,7 @@ func CmdCreate(hostname, pubKeyPath, privKeyPath string, selfSigned, resolve boo
 		return err
 	}
 	logrus.Printf("Created '%s'", hostname)
+	logrus.Println("To make use of your cert, you need to add a site with the \"catalyze sites create\" command")
 	return nil
 }
 

--- a/commands/certs/update.go
+++ b/commands/certs/update.go
@@ -59,6 +59,7 @@ func CmdUpdate(hostname, pubKeyPath, privKeyPath string, selfSigned, resolve boo
 		return err
 	}
 	logrus.Printf("Updated '%s'", hostname)
+	logrus.Println("To make your updated cert go live, you must redeploy your service proxy with the \"catalyze redeploy service_proxy\" command")
 	return nil
 }
 

--- a/commands/console/console.go
+++ b/commands/console/console.go
@@ -25,7 +25,7 @@ func CmdConsole(svcName, command string, ic IConsole, is services.IServices) err
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the name \"%s\". You can list services with the \"catalyze services\" command.\n", svcName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.\n", svcName)
 	}
 	return ic.Open(command, service)
 }

--- a/commands/console/console.go
+++ b/commands/console/console.go
@@ -25,7 +25,7 @@ func CmdConsole(svcName, command string, ic IConsole, is services.IServices) err
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the name \"%s\"\n", svcName)
+		return fmt.Errorf("Could not find a service with the name \"%s\". You can list services with the \"catalyze services\" command.\n", svcName)
 	}
 	return ic.Open(command, service)
 }

--- a/commands/db/backup.go
+++ b/commands/db/backup.go
@@ -16,7 +16,7 @@ func CmdBackup(databaseName string, skipPoll bool, id IDb, is services.IServices
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the label \"%s\"", databaseName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", databaseName)
 	}
 	job, err := id.Backup(service)
 	if err != nil {
@@ -40,6 +40,7 @@ func CmdBackup(databaseName string, skipPoll bool, id IDb, is services.IServices
 			return fmt.Errorf("Job finished with invalid status %s", job.Status)
 		}
 	}
+	logrus.Printf("You can download your backup with the \"catalyze db download %s %s ./output_file_path\" command", databaseName, job.ID)
 	return nil
 }
 

--- a/commands/db/download.go
+++ b/commands/db/download.go
@@ -37,13 +37,14 @@ func CmdDownload(databaseName, backupID, filePath string, force bool, id IDb, ip
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the label \"%s\"", databaseName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", databaseName)
 	}
 	err = id.Download(backupID, filePath, service)
 	if err != nil {
 		return err
 	}
 	logrus.Printf("%s backup downloaded successfully to %s", databaseName, filePath)
+	logrus.Printf("You can also view logs for this backup with the \"catalyze db logs %s %s\" command", databaseName, backupID)
 	return nil
 }
 

--- a/commands/db/export.go
+++ b/commands/db/export.go
@@ -31,7 +31,7 @@ func CmdExport(databaseName, filePath string, force bool, id IDb, ip prompts.IPr
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the label \"%s\"", databaseName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", databaseName)
 	}
 	job, err := id.Backup(service)
 	if err != nil {

--- a/commands/db/import.go
+++ b/commands/db/import.go
@@ -29,7 +29,7 @@ func CmdImport(databaseName, filePath, mongoCollection, mongoDatabase string, id
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the label \"%s\"", databaseName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", databaseName)
 	}
 	logrus.Printf("Backing up \"%s\" before performing the import", databaseName)
 	job, err := id.Backup(service)

--- a/commands/db/list.go
+++ b/commands/db/list.go
@@ -16,7 +16,7 @@ func CmdList(databaseName string, page, pageSize int, id IDb, is services.IServi
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the label \"%s\"", databaseName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", databaseName)
 	}
 	jobs, err := id.List(page, pageSize, service)
 	if err != nil {
@@ -31,6 +31,8 @@ func CmdList(databaseName string, page, pageSize int, id IDb, is services.IServi
 	}
 	if len(*jobs) == 0 && page == 1 {
 		logrus.Println("No backups created yet for this service.")
+	} else if len(*jobs) == 0 {
+		logrus.Println("No backups found with the given parameters.")
 	}
 	return nil
 }

--- a/commands/db/logs.go
+++ b/commands/db/logs.go
@@ -20,7 +20,7 @@ func CmdLogs(databaseName, backupID string, id IDb, is services.IServices, ij jo
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the label \"%s\"", databaseName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", databaseName)
 	}
 	job, err := ij.Retrieve(backupID, service.ID, false)
 	if err != nil {

--- a/commands/deploykeys/add.go
+++ b/commands/deploykeys/add.go
@@ -27,7 +27,7 @@ func CmdAdd(name, keyPath, svcName string, id IDeployKeys, is services.IServices
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the label \"%s\"", svcName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
 	}
 	if service.Type != "code" {
 		return fmt.Errorf("You can only add deploy keys to code services, not %s services", service.Type)

--- a/commands/deploykeys/list.go
+++ b/commands/deploykeys/list.go
@@ -19,15 +19,19 @@ func CmdList(svcName string, id IDeployKeys, is services.IServices) error {
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the label \"%s\"", svcName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
 	}
 	if service.Type != "code" {
-		return fmt.Errorf("You can only list deploy keys to code services, not %s services", service.Type)
+		return fmt.Errorf("You can only list deploy keys for code services, not %s services", service.Type)
 	}
 
 	keys, err := id.List(service.ID)
 	if err != nil {
 		return err
+	}
+	if keys == nil || len(*keys) == 0 {
+		logrus.Println("No deploy-keys found")
+		return nil
 	}
 
 	invalidKeys := map[string]string{}

--- a/commands/deploykeys/rm.go
+++ b/commands/deploykeys/rm.go
@@ -18,7 +18,7 @@ func CmdRm(name, svcName string, id IDeployKeys, is services.IServices) error {
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the label \"%s\"", svcName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
 	}
 	if service.Type != "code" {
 		return fmt.Errorf("You can only remove a deploy keys from code services, not %s services", service.Type)

--- a/commands/disassociate/disassociate.go
+++ b/commands/disassociate/disassociate.go
@@ -10,7 +10,7 @@ func CmdDisassociate(alias string, id IDisassociate) error {
 	if err != nil {
 		return err
 	}
-	logrus.Printf("WARNING: Your existing git remote *has not* been removed.\n")
+	logrus.Println("WARNING: Your existing git remote *has not* been removed.")
 	logrus.Println("Association cleared.")
 	return nil
 }

--- a/commands/environments/environments.go
+++ b/commands/environments/environments.go
@@ -14,11 +14,12 @@ func CmdEnvironments(environments IEnvironments) error {
 	if err != nil {
 		return err
 	}
+	if envs == nil || len(*envs) == 0 {
+		logrus.Println("no environments found")
+		return nil
+	}
 	for _, env := range *envs {
 		logrus.Printf("%s: %s", env.Name, env.ID)
-	}
-	if len(*envs) == 0 {
-		logrus.Println("no environments found")
 	}
 	return nil
 }

--- a/commands/files/download.go
+++ b/commands/files/download.go
@@ -20,7 +20,7 @@ import (
 func CmdDownload(svcName, fileName, output string, force bool, ifiles IFiles, is services.IServices) error {
 	if output != "" && !force {
 		if _, err := os.Stat(output); err == nil {
-			return fmt.Errorf("File already exists at path '%s'. Specify `--force` to overwrite", output)
+			return fmt.Errorf("File already exists at path '%s'. Specify '--force' to overwrite", output)
 		}
 	}
 	service, err := is.RetrieveByLabel(svcName)
@@ -28,14 +28,14 @@ func CmdDownload(svcName, fileName, output string, force bool, ifiles IFiles, is
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the name \"%s\"", svcName)
+		return fmt.Errorf("Could not find a service with the name \"%s\". You can list services with the \"catalyze services\" command.", svcName)
 	}
 	file, err := ifiles.Retrieve(fileName, service.ID)
 	if err != nil {
 		return err
 	}
 	if file == nil {
-		return fmt.Errorf("File with name %s does not exist. Try listing files again by running \"catalyze files list\"", fileName)
+		return fmt.Errorf("File with name %s does not exist. Try listing files again by running \"catalyze files list %s\"", fileName, svcName)
 	}
 	return ifiles.Save(output, force, file)
 }

--- a/commands/files/download.go
+++ b/commands/files/download.go
@@ -28,7 +28,7 @@ func CmdDownload(svcName, fileName, output string, force bool, ifiles IFiles, is
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the name \"%s\". You can list services with the \"catalyze services\" command.", svcName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
 	}
 	file, err := ifiles.Retrieve(fileName, service.ID)
 	if err != nil {

--- a/commands/files/list.go
+++ b/commands/files/list.go
@@ -19,7 +19,7 @@ func CmdList(svcName string, ifiles IFiles, is services.IServices) error {
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the name \"%s\". You can list services with the \"catalyze services\" command.", svcName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
 	}
 	files, err := ifiles.List(service.ID)
 	if err != nil {

--- a/commands/files/list.go
+++ b/commands/files/list.go
@@ -19,13 +19,13 @@ func CmdList(svcName string, ifiles IFiles, is services.IServices) error {
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the name \"%s\"", svcName)
+		return fmt.Errorf("Could not find a service with the name \"%s\". You can list services with the \"catalyze services\" command.", svcName)
 	}
 	files, err := ifiles.List(service.ID)
 	if err != nil {
 		return err
 	}
-	if len(*files) == 0 {
+	if files == nil || len(*files) == 0 {
 		logrus.Println("No service files found")
 		return nil
 	}
@@ -33,6 +33,7 @@ func CmdList(svcName string, ifiles IFiles, is services.IServices) error {
 	for _, sf := range *files {
 		logrus.Println(sf.Name)
 	}
+	logrus.Printf("\nTo view the contents of a service file, use the \"catalyze files download %s FILE_NAME\" command", svcName)
 	return nil
 }
 

--- a/commands/invites/list.go
+++ b/commands/invites/list.go
@@ -13,7 +13,7 @@ func CmdList(envName string, ii IInvites) error {
 	if err != nil {
 		return err
 	}
-	if len(*invts) == 0 {
+	if invts == nil || len(*invts) == 0 {
 		logrus.Printf("There are no pending invites for %s", envName)
 		return nil
 	}

--- a/commands/keys/add.go
+++ b/commands/keys/add.go
@@ -41,6 +41,7 @@ func CmdAdd(name, path string, ik IKeys, id deploykeys.IDeployKeys) error {
 		return err
 	}
 	logrus.Printf("Key '%s' added to your account.", name)
+	logrus.Println("If you use an ssh-agent, make sure you add this key to your ssh-agent in order to push code")
 	return nil
 }
 

--- a/commands/keys/list.go
+++ b/commands/keys/list.go
@@ -19,6 +19,11 @@ func CmdList(ik IKeys, id deploykeys.IDeployKeys) error {
 		return err
 	}
 
+	if keys == nil || len(*keys) == 0 {
+		logrus.Println("No keys found")
+		return nil
+	}
+
 	invalidKeys := map[string]string{}
 
 	data := [][]string{{"NAME", "FINGERPRINT"}}

--- a/commands/logout/logout.go
+++ b/commands/logout/logout.go
@@ -1,9 +1,13 @@
 package logout
 
-import "github.com/catalyzeio/cli/lib/auth"
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/catalyzeio/cli/lib/auth"
+)
 
 func CmdLogout(il ILogout, ia auth.IAuth) error {
 	ia.Signout()
+	logrus.Println("You have been logged out")
 	return il.Clear()
 }
 

--- a/commands/logs/logs.go
+++ b/commands/logs/logs.go
@@ -58,7 +58,7 @@ func CmdLogs(queryString string, follow bool, hours, minutes, seconds int, envID
 		}
 	}
 	if domain == "" {
-		return errors.New("Could not determine the fully qualified domain name of your environment")
+		return errors.New("Could not determine the fully qualified domain name of your environment. Please contact Catalyze Support at support@catalyze.io with this error message to resolve this issue.")
 	}
 	from := 0
 	offset := time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute + time.Duration(seconds)*time.Second

--- a/commands/rake/rake.go
+++ b/commands/rake/rake.go
@@ -14,7 +14,7 @@ func CmdRake(taskName string, ir IRake) error {
 	if err != nil {
 		return err
 	}
-	logrus.Println("Rake task output viewable in your logging server")
+	logrus.Println("Rake task output viewable in your logging dashboard")
 	return nil
 }
 

--- a/commands/redeploy/redeploy.go
+++ b/commands/redeploy/redeploy.go
@@ -15,14 +15,14 @@ func CmdRedeploy(svcName string, ir IRedeploy, is services.IServices) error {
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the name \"%s\"", svcName)
+		return fmt.Errorf("Could not find a service with the name \"%s\". You can list services with the \"catalyze services\" command.", svcName)
 	}
 	logrus.Printf("Redeploying %s (ID = %s)", svcName, service.ID)
 	err = ir.Redeploy(service)
 	if err != nil {
 		return err
 	}
-	logrus.Println("Redeploy successful! Check the status and logs for updates")
+	logrus.Println("Redeploy successful! Check the status with \"catalyze status\" and your logging dashboard for updates")
 	return nil
 }
 

--- a/commands/redeploy/redeploy.go
+++ b/commands/redeploy/redeploy.go
@@ -15,7 +15,7 @@ func CmdRedeploy(svcName string, ir IRedeploy, is services.IServices) error {
 		return err
 	}
 	if service == nil {
-		return fmt.Errorf("Could not find a service with the name \"%s\". You can list services with the \"catalyze services\" command.", svcName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
 	}
 	logrus.Printf("Redeploying %s (ID = %s)", svcName, service.ID)
 	err = ir.Redeploy(service)

--- a/commands/services/services.go
+++ b/commands/services/services.go
@@ -15,6 +15,10 @@ func CmdServices(is IServices) error {
 	if err != nil {
 		return err
 	}
+	if svcs == nil || len(*svcs) == 0 {
+		logrus.Println("No services found")
+		return nil
+	}
 	data := [][]string{{"NAME", "RAM (GB)", "CPU", "STORAGE (GB)"}}
 	for _, s := range *svcs {
 		data = append(data, []string{s.Label, fmt.Sprintf("%d", s.Size.RAM), fmt.Sprintf("%d", s.Size.CPU), fmt.Sprintf("%d", s.Size.Storage)})

--- a/commands/sites/create.go
+++ b/commands/sites/create.go
@@ -16,7 +16,7 @@ func CmdCreate(name, serviceName, hostname string, is ISites, iservices services
 		return err
 	}
 	if upstreamService == nil {
-		return fmt.Errorf("Could not find a service with the label \"%s\"", serviceName)
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", serviceName)
 	}
 
 	serviceProxy, err := iservices.RetrieveByLabel("service_proxy")
@@ -29,6 +29,7 @@ func CmdCreate(name, serviceName, hostname string, is ISites, iservices services
 		return err
 	}
 	logrus.Printf("Created '%s'", site.Name)
+	logrus.Println("To make your site go live, you must redeploy your service proxy with the \"catalyze redeploy service_proxy\" command")
 	return nil
 }
 

--- a/commands/sites/rm.go
+++ b/commands/sites/rm.go
@@ -25,13 +25,14 @@ func CmdRm(name string, is ISites, iservices services.IServices) error {
 		}
 	}
 	if site == nil {
-		return fmt.Errorf("Could not find a site with the name \"%s\"", name)
+		return fmt.Errorf("Could not find a site with the name \"%s\". You can list sites with the \"catalyze sites list\" command.", name)
 	}
 	err = is.Rm(site.ID, serviceProxy.ID)
 	if err != nil {
 		return err
 	}
 	logrus.Println("Site removed")
+	logrus.Println("To make your changes go live, you must redeploy your service proxy with the \"catalyze redeploy service_proxy\" command")
 	return nil
 }
 

--- a/commands/sites/rm.go
+++ b/commands/sites/rm.go
@@ -25,7 +25,7 @@ func CmdRm(name string, is ISites, iservices services.IServices) error {
 		}
 	}
 	if site == nil {
-		return fmt.Errorf("Could not find a site with the name \"%s\". You can list sites with the \"catalyze sites list\" command.", name)
+		return fmt.Errorf("Could not find a site with the label \"%s\". You can list sites with the \"catalyze sites list\" command.", name)
 	}
 	err = is.Rm(site.ID, serviceProxy.ID)
 	if err != nil {

--- a/commands/sites/show.go
+++ b/commands/sites/show.go
@@ -26,7 +26,7 @@ func CmdShow(name string, is ISites, iservices services.IServices) error {
 		}
 	}
 	if site == nil {
-		return fmt.Errorf("Could not find a site with the name \"%s\". You can list sites with the \"catalyze sites list\" command.", name)
+		return fmt.Errorf("Could not find a site with the label \"%s\". You can list sites with the \"catalyze sites list\" command.", name)
 	}
 	site, err = is.Retrieve(site.ID, serviceProxy.ID)
 	if err != nil {

--- a/commands/sites/show.go
+++ b/commands/sites/show.go
@@ -26,7 +26,7 @@ func CmdShow(name string, is ISites, iservices services.IServices) error {
 		}
 	}
 	if site == nil {
-		return fmt.Errorf("Could not find a site with the name \"%s\"", name)
+		return fmt.Errorf("Could not find a site with the name \"%s\". You can list sites with the \"catalyze sites list\" command.", name)
 	}
 	site, err = is.Retrieve(site.ID, serviceProxy.ID)
 	if err != nil {

--- a/commands/supportids/contract.go
+++ b/commands/supportids/contract.go
@@ -26,7 +26,7 @@ var Cmd = models.Command{
 
 // ISupportIDs
 type ISupportIDs interface {
-	SupportIDs() (string, string, string, string, error)
+	SupportIDs() (string, string, string, string, string, error)
 }
 
 // SSupportIDs is a concrete implementation of ISupportIDs

--- a/commands/supportids/support_ids.go
+++ b/commands/supportids/support_ids.go
@@ -3,19 +3,20 @@ package supportids
 import "github.com/Sirupsen/logrus"
 
 func CmdSupportIDs(is ISupportIDs) error {
-	envID, orgID, usersID, svcID, err := is.SupportIDs()
+	envID, orgID, usersID, svcID, podID, err := is.SupportIDs()
 	if err != nil {
 		return err
 	}
 	logrus.Printf(`EnvironmentID:  %s
 OrganizationID: %s
 UsersID:        %s
-ServiceID:      %s`, envID, orgID, usersID, svcID)
+ServiceID:      %s
+PodID:          %s`, envID, orgID, usersID, svcID, podID)
 	return nil
 }
 
 // SupportIDs prints out various IDs related to the associated environment to be
 // used when contacting Catalyze support at support@catalyze.io.
-func (s *SSupportIDs) SupportIDs() (string, string, string, string, error) {
-	return s.Settings.EnvironmentID, s.Settings.OrgID, s.Settings.UsersID, s.Settings.ServiceID, nil
+func (s *SSupportIDs) SupportIDs() (string, string, string, string, string, error) {
+	return s.Settings.EnvironmentID, s.Settings.OrgID, s.Settings.UsersID, s.Settings.ServiceID, s.Settings.Pod, nil
 }

--- a/commands/users/list.go
+++ b/commands/users/list.go
@@ -16,6 +16,10 @@ func CmdList(myUsersID string, iu IUsers, ii invites.IInvites) error {
 	if err != nil {
 		return err
 	}
+	if orgUsers == nil || len(*orgUsers) == 0 {
+		logrus.Println("No users found")
+		return nil
+	}
 	roles, err := ii.ListRoles()
 	if err != nil {
 		return err

--- a/commands/users/rm.go
+++ b/commands/users/rm.go
@@ -27,7 +27,7 @@ func CmdRm(email string, iu IUsers) error {
 	if err != nil {
 		return err
 	}
-	logrus.Println("Removed.")
+	logrus.Printf("Removed %s from your environment's organization.", email)
 	return nil
 }
 

--- a/commands/vars/list.go
+++ b/commands/vars/list.go
@@ -13,6 +13,10 @@ func CmdList(iv IVars) error {
 	if err != nil {
 		return err
 	}
+	if len(envVars) == 0 {
+		logrus.Println("No environment variables found")
+		return nil
+	}
 	var keys []string
 	for k := range envVars {
 		keys = append(keys, k)

--- a/commands/vars/set.go
+++ b/commands/vars/set.go
@@ -29,6 +29,8 @@ func CmdSet(variables []string, iv IVars) error {
 	if err != nil {
 		return err
 	}
+	// TODO add in the service label in the redeploy example once we take in the service label in
+	// this command
 	logrus.Println("Set. For these environment variables to take effect, you will need to redeploy your service with \"catalyze redeploy\"")
 	return nil
 }

--- a/commands/vars/unset.go
+++ b/commands/vars/unset.go
@@ -12,6 +12,8 @@ func CmdUnset(key string, iv IVars) error {
 	if err != nil {
 		return err
 	}
+	// TODO add in the service label in the redeploy example once we take in the service label in
+	// this command
 	logrus.Println("Unset. For these environment variable changes to take effect, you will need to redeploy your service with \"catalyze redeploy\"")
 	return nil
 }

--- a/commands/vars/unset.go
+++ b/commands/vars/unset.go
@@ -12,7 +12,7 @@ func CmdUnset(key string, iv IVars) error {
 	if err != nil {
 		return err
 	}
-	logrus.Println("Unset.")
+	logrus.Println("Unset. For these environment variable changes to take effect, you will need to redeploy your service with \"catalyze redeploy\"")
 	return nil
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -87,10 +87,10 @@ type OrgUser struct {
 
 // Environment environment
 type Environment struct {
-	ID        string `json:"id"`
+	ID        string `json:"id,omitempty"`
 	Name      string `json:"name"`
-	Pod       string `json:"pod"`
-	Namespace string `json:"namespace"`
+	Pod       string `json:"pod,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
 	OrgID     string `json:"organizationId"`
 }
 
@@ -118,15 +118,16 @@ type Payload struct {
 
 // Service service
 type Service struct {
-	ID      string            `json:"id,omitempty"`
-	Type    string            `json:"type,omitempty"`
-	Label   string            `json:"label"`
-	Size    ServiceSize       `json:"size"`
-	Name    string            `json:"name"`
-	EnvVars map[string]string `json:"environmentVariables,omitempty"`
-	Source  string            `json:"source,omitempty"`
-	LBIP    string            `json:"load_balancer_ip,omitempty"`
-	Scale   int               `json:"scale,omitempty"`
+	ID          string            `json:"id,omitempty"`
+	Type        string            `json:"type,omitempty"`
+	Label       string            `json:"label"`
+	Size        ServiceSize       `json:"size"`
+	Name        string            `json:"name"`
+	EnvVars     map[string]string `json:"environmentVariables,omitempty"`
+	Source      string            `json:"source,omitempty"`
+	LBIP        string            `json:"load_balancer_ip,omitempty"`
+	Scale       int               `json:"scale,omitempty"`
+	WorkerScale int               `json:"worker_scale,omitempty"`
 }
 
 // ServiceSize holds size information for a service
@@ -279,6 +280,7 @@ type Site struct {
 	Cert            string `json:"cert"`
 	SiteFileID      int    `json:"siteFileId,omitempty"`
 	UpstreamService string `json:"upstreamService"`
+	Restricted      bool   `json:"restricted,omitempty"`
 }
 
 type Cert struct {
@@ -286,9 +288,10 @@ type Cert struct {
 	PubKey  string `json:"sslCertFile"`
 	PrivKey string `json:"sslPKFile"`
 
-	Service   string `json:"service,omitempty"`
-	PubKeyID  int    `json:"sslCertFileId,omitempty"`
-	PrivKeyID int    `json:"sslPKFileId,omitempty"`
+	Service    string `json:"service,omitempty"`
+	PubKeyID   int    `json:"sslCertFileId,omitempty"`
+	PrivKeyID  int    `json:"sslPKFileId,omitempty"`
+	Restricted bool   `json:"restricted,omitempty"`
 }
 
 // UserKey is a public key belonging to a user

--- a/models/models.go
+++ b/models/models.go
@@ -29,7 +29,7 @@ type Error struct {
 
 // ReportedError is the standard error model sent back from the API
 type ReportedError struct {
-	Code    int    `json:"code"`
+	Code    int    `json:"id"`
 	Message string `json:"message"`
 }
 


### PR DESCRIPTION
The primary driver behind this PR is enhanced notifications around what commands you can run and when along with better error messages. Notifications are intended to tell you what to do after you successfully run commands such as after creating a `cert`, you need to create a `site`. Then after creating a `site` you need to redeploy your service_proxy to make the changes go live. This PR helps address many of those situations.

I also added a few checks for the various `list` commands to output `No X found` instead of returning and printing nothing.

Error messages also now include more text on how to resolve the errors. One big example is when you run a command that takes in a service name, it may have printed out the error `Service with name X not found`. This has now been changed to `Service with name X not found. You can list all services with the "catalyze services" command` to help guide users in the right direction when the CLI returns unexpected results. More error formats are also handled now so JSON errors will be avoided.

As a bonus, the http client is now a package var instead of creating a new instance each time. In testing, I found that I hit open file descriptor limits when the client was not reused.