### PR TITLE
Added resiliency for pods that are inaccessible

### DIFF
--- a/catalyze/catalyze.go
+++ b/catalyze/catalyze.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/catalyzeio/cli/commands/associate"
 	"github.com/catalyzeio/cli/commands/associated"
@@ -129,7 +130,8 @@ func Run() {
 		*settings = *r.GetSettings(*givenEnvName, "", accountsHost, authHost, "", paasHost, "", *username, *password)
 		logrus.Debugf("%+v", settings)
 
-		if settings.Pods == nil || len(*settings.Pods) == 0 {
+		if settings.Pods == nil || len(*settings.Pods) == 0 || settings.PodCheck < time.Now().Unix() {
+			settings.PodCheck = time.Now().Unix() + 86400
 			p := pods.New(settings)
 			pods, err := p.List()
 			if err == nil {

--- a/commands/associate/associate.go
+++ b/commands/associate/associate.go
@@ -22,7 +22,7 @@ func CmdAssociate(envLabel, svcLabel, alias, remote string, defaultEnv bool, ia 
 	envs, errs := ie.List()
 	if errs != nil && len(errs) > 0 {
 		for pod, err := range errs {
-			logrus.Errorf("Failed to list environments for pod \"%s\": %s", pod, err)
+			logrus.Debugf("Failed to list environments for pod \"%s\": %s", pod, err)
 		}
 	}
 	var e *models.Environment

--- a/commands/environments/contract.go
+++ b/commands/environments/contract.go
@@ -79,7 +79,7 @@ var RenameSubCmd = models.Command{
 
 // IEnvironments is an interface for interacting with environments
 type IEnvironments interface {
-	List() (*[]models.Environment, error)
+	List() (*[]models.Environment, map[string]error)
 	Retrieve(envID string) (*models.Environment, error)
 	Update(envID string, updates map[string]string) error
 }

--- a/commands/environments/list.go
+++ b/commands/environments/list.go
@@ -1,6 +1,7 @@
 package environments
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
@@ -10,39 +11,45 @@ import (
 
 // CmdList lists all environments which the user has access to
 func CmdList(environments IEnvironments) error {
-	envs, err := environments.List()
-	if err != nil {
-		return err
-	}
+	envs, errs := environments.List()
 	if envs == nil || len(*envs) == 0 {
 		logrus.Println("no environments found")
-		return nil
+	} else {
+		for _, env := range *envs {
+			logrus.Printf("%s: %s", env.Name, env.ID)
+		}
 	}
-	for _, env := range *envs {
-		logrus.Printf("%s: %s", env.Name, env.ID)
+	if errs != nil && len(errs) > 0 {
+		for pod, err := range errs {
+			defer logrus.Errorf("Failed to list environments for pod \"%s\": %s", pod, err)
+		}
+		return errors.New("Failures listing environments. Please try again or contact support@catalyze.io if this issue persists.")
 	}
 	return nil
 }
 
-func (e *SEnvironments) List() (*[]models.Environment, error) {
-	var allEnvs []models.Environment
+func (e *SEnvironments) List() (*[]models.Environment, map[string]error) {
+	allEnvs := []models.Environment{}
+	errs := map[string]error{}
 	for _, pod := range *e.Settings.Pods {
 		headers := httpclient.GetHeaders(e.Settings.SessionToken, e.Settings.Version, pod.Name, e.Settings.UsersID)
 		resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments", e.Settings.PaasHost, e.Settings.PaasHostVersion), headers)
 		if err != nil {
-			return nil, err
+			errs[pod.Name] = err
+			continue
 		}
 		var envs []models.Environment
 		err = httpclient.ConvertResp(resp, statusCode, &envs)
 		if err != nil {
-			return nil, err
+			errs[pod.Name] = err
+			continue
 		}
 		for i := 0; i < len(envs); i++ {
 			envs[i].Pod = pod.Name
 		}
 		allEnvs = append(allEnvs, envs...)
 	}
-	return &allEnvs, nil
+	return &allEnvs, errs
 }
 
 func (e *SEnvironments) Retrieve(envID string) (*models.Environment, error) {

--- a/commands/environments/list.go
+++ b/commands/environments/list.go
@@ -12,7 +12,7 @@ import (
 func CmdList(environments IEnvironments) error {
 	envs, errs := environments.List()
 	if envs == nil || len(*envs) == 0 {
-		logrus.Println("No environments found. If this is incorrect, please contact support@catalyze.io.")
+		logrus.Println("no environments found")
 	} else {
 		for _, env := range *envs {
 			logrus.Printf("%s: %s", env.Name, env.ID)
@@ -22,6 +22,7 @@ func CmdList(environments IEnvironments) error {
 		for pod, err := range errs {
 			logrus.Debugf("Failed to list environments for pod \"%s\": %s", pod, err)
 		}
+		logrus.Println("If the environment you're looking for is not listed, ensure you have the correct permissions from your organization owner. If the environment is still not listed, please contact support@catalyze.io.")
 	}
 	return nil
 }

--- a/commands/environments/list.go
+++ b/commands/environments/list.go
@@ -1,7 +1,6 @@
 package environments
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
@@ -13,7 +12,7 @@ import (
 func CmdList(environments IEnvironments) error {
 	envs, errs := environments.List()
 	if envs == nil || len(*envs) == 0 {
-		logrus.Println("no environments found")
+		logrus.Println("No environments found. If this is incorrect, please contact support@catalyze.io.")
 	} else {
 		for _, env := range *envs {
 			logrus.Printf("%s: %s", env.Name, env.ID)
@@ -21,9 +20,8 @@ func CmdList(environments IEnvironments) error {
 	}
 	if errs != nil && len(errs) > 0 {
 		for pod, err := range errs {
-			defer logrus.Errorf("Failed to list environments for pod \"%s\": %s", pod, err)
+			logrus.Debugf("Failed to list environments for pod \"%s\": %s", pod, err)
 		}
-		return errors.New("Failures listing environments. Please try again or contact support@catalyze.io if this issue persists.")
 	}
 	return nil
 }

--- a/commands/logs/contract.go
+++ b/commands/logs/contract.go
@@ -26,7 +26,7 @@ var Cmd = models.Command{
 			follow := cmd.BoolOpt("f follow", false, "Tail/follow the logs (Equivalent to -t)")
 			tail := cmd.BoolOpt("t tail", false, "Tail/follow the logs (Equivalent to -f)")
 			hours := cmd.IntOpt("hours", 0, "The number of hours before now (in combination with minutes and seconds) to retrieve logs")
-			mins := cmd.IntOpt("minutes", 1, "The number of minutes before now (in combination with hours and seconds) to retrieve logs")
+			mins := cmd.IntOpt("minutes", 0, "The number of minutes before now (in combination with hours and seconds) to retrieve logs")
 			secs := cmd.IntOpt("seconds", 0, "The number of seconds before now (in combination with hours and minutes) to retrieve logs")
 			cmd.Action = func() {
 				if _, err := auth.New(settings, prompts.New()).Signin(); err != nil {

--- a/commands/logs/logs.go
+++ b/commands/logs/logs.go
@@ -27,6 +27,10 @@ const size = 50
 // not very cohesive. This is intended to be similar to the `heroku logs`
 // command.
 func CmdLogs(queryString string, follow bool, hours, minutes, seconds int, envID string, settings *models.Settings, il ILogs, ip prompts.IPrompts, ie environments.IEnvironments, is services.IServices, isites sites.ISites) error {
+	if follow && (hours > 0 || minutes > 0 || seconds > 0) {
+		logrus.Warnln("Specifying \"logs -f\" in combination with \"--hours\", \"--minutes\", or \"--seconds\" has been deprecated!")
+		logrus.Warnln("Please specify either \"-f\" or use \"--hours\", \"--minutes\", \"--seconds\" but not both. Support for \"-f\" and a specified time frame will be removed in a later version.")
+	}
 	env, err := ie.Retrieve(envID)
 	if err != nil {
 		return err

--- a/commands/update/contract.go
+++ b/commands/update/contract.go
@@ -19,7 +19,6 @@ var Cmd = models.Command{
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
-				updatePods(settings)
 			}
 		}
 	},
@@ -29,6 +28,7 @@ var Cmd = models.Command{
 type IUpdate interface {
 	Check() (bool, error)
 	Update() error
+	UpdatePods()
 }
 
 // SUpdate is a concrete implementation of IUpdate

--- a/commands/update/update.go
+++ b/commands/update/update.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/catalyzeio/cli/lib/pods"
 	"github.com/catalyzeio/cli/lib/updater"
-	"github.com/catalyzeio/cli/models"
 )
 
 func CmdUpdate(iu IUpdate) error {
@@ -33,6 +32,7 @@ func CmdUpdate(iu IUpdate) error {
 	if err != nil {
 		return err
 	}
+	iu.UpdatePods()
 	logrus.Printf("Your CLI has been updated to version %s", updater.AutoUpdater.Info.Version)
 	return nil
 }
@@ -55,14 +55,15 @@ func (u *SUpdate) Update() error {
 	return nil
 }
 
-func updatePods(settings *models.Settings) {
+// UpdatePods retrieves the latest list of pods and refreshes the local cache. If an error occurs,
+// the local cache is unchanged.
+func (u *SUpdate) UpdatePods() {
 	logrus.Debugf("Updating cached pods...")
-	p := pods.New(settings)
+	p := pods.New(u.Settings)
 	pods, err := p.List()
 	if err == nil {
-		settings.Pods = pods
+		u.Settings.Pods = pods
 	} else {
-		settings.Pods = &[]models.Pod{}
 		logrus.Debugf("Error listing pods: %s", err.Error())
 	}
 }

--- a/models/models.go
+++ b/models/models.go
@@ -166,6 +166,7 @@ type Settings struct {
 	Environments    map[string]AssociatedEnv `json:"environments"`
 	Default         string                   `json:"default"`
 	Pods            *[]Pod                   `json:"pods"`
+	PodCheck        int64                    `json:"pod_check"`
 }
 
 // PodWrapper pod wrapper
@@ -188,16 +189,6 @@ type AssociatedEnv struct {
 	Name          string `json:"name"`
 	Pod           string `json:"pod"`
 	OrgID         string `json:"organizationId"`
-}
-
-// Breadcrumb is stored in a local git repo to make a link back to the
-// global list of associated envs
-type Breadcrumb struct {
-	EnvName       string `json:"env_name"`
-	EnvironmentID string `json:"environmentId,omitempty"` // for backwards compatibility
-	ServiceID     string `json:"serviceId,omitempty"`     // for backwards compatibility
-	SessionToken  string `json:"token,omitempty"`         // for backwards compatibility
-	UsersID       string `json:"user_id,omitempty"`       // for backwards compatibility
 }
 
 // ConsoleCredentials hold the keys necessary for connecting to a console service


### PR DESCRIPTION
These changes ensures that the `associate` and `environments list` commands output as much information as possible without exiting early if a single pod becomes inaccessible. The `environments list` command will list all environments found then debug log any errors encountered. The command will return a zero exit code.

The `associate` command will debug log any errors encountered listing environments, but it will function as normal if the environment is still found.

Specifying `logs -f` along with any of `--hours`, `--minutes`, and `--seconds` has been deprecated. Moving forward, `logs -f` will be for streaming incoming logs without outputting previous logs.

The internal list of available pods now updates once every 24 hours.