### PR TITLE
maintenance mode commands to enable, disable, and show status

### DIFF
--- a/catalyze/catalyze.go
+++ b/catalyze/catalyze.go
@@ -24,6 +24,7 @@ import (
 	"github.com/catalyzeio/cli/commands/keys"
 	"github.com/catalyzeio/cli/commands/logout"
 	"github.com/catalyzeio/cli/commands/logs"
+	"github.com/catalyzeio/cli/commands/maintenance"
 	"github.com/catalyzeio/cli/commands/metrics"
 	"github.com/catalyzeio/cli/commands/rake"
 	"github.com/catalyzeio/cli/commands/redeploy"
@@ -185,6 +186,7 @@ func InitCLI(app *cli.Cli, settings *models.Settings) {
 	app.CommandLong(keys.Cmd.Name, keys.Cmd.ShortHelp, keys.Cmd.LongHelp, keys.Cmd.CmdFunc(settings))
 	app.CommandLong(logout.Cmd.Name, logout.Cmd.ShortHelp, logout.Cmd.LongHelp, logout.Cmd.CmdFunc(settings))
 	app.CommandLong(logs.Cmd.Name, logs.Cmd.ShortHelp, logs.Cmd.LongHelp, logs.Cmd.CmdFunc(settings))
+	app.CommandLong(maintenance.Cmd.Name, maintenance.Cmd.ShortHelp, maintenance.Cmd.LongHelp, maintenance.Cmd.CmdFunc(settings))
 	app.CommandLong(metrics.Cmd.Name, metrics.Cmd.ShortHelp, metrics.Cmd.LongHelp, metrics.Cmd.CmdFunc(settings))
 	app.CommandLong(rake.Cmd.Name, rake.Cmd.ShortHelp, rake.Cmd.LongHelp, rake.Cmd.CmdFunc(settings))
 	app.CommandLong(redeploy.Cmd.Name, redeploy.Cmd.ShortHelp, redeploy.Cmd.LongHelp, redeploy.Cmd.CmdFunc(settings))

--- a/commands/deploykeys/rm.go
+++ b/commands/deploykeys/rm.go
@@ -21,7 +21,7 @@ func CmdRm(name, svcName string, id IDeployKeys, is services.IServices) error {
 		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
 	}
 	if service.Type != "code" {
-		return fmt.Errorf("You can only remove a deploy keys from code services, not %s services", service.Type)
+		return fmt.Errorf("You can only remove deploy keys from code services, not %s services", service.Type)
 	}
 	return id.Rm(name, "ssh", service.ID)
 }

--- a/commands/maintenance/contract.go
+++ b/commands/maintenance/contract.go
@@ -1,0 +1,128 @@
+package maintenance
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/catalyzeio/cli/commands/services"
+	"github.com/catalyzeio/cli/config"
+	"github.com/catalyzeio/cli/lib/auth"
+	"github.com/catalyzeio/cli/lib/prompts"
+	"github.com/catalyzeio/cli/models"
+	"github.com/jault3/mow.cli"
+)
+
+// Cmd is the contract between the user and the CLI. This specifies the command
+// name, arguments, and required/optional arguments and flags for the command.
+var Cmd = models.Command{
+	Name:      "maintenance",
+	ShortHelp: "Manage maintenance mode for code services",
+	LongHelp: "Maintenance mode can be enabled or disabled for code services " +
+		"on demand. This redirects all traffic to a default maintenance page.",
+	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
+		return func(cmd *cli.Cmd) {
+			cmd.CommandLong(DisableSubCmd.Name, DisableSubCmd.ShortHelp, DisableSubCmd.LongHelp, DisableSubCmd.CmdFunc(settings))
+			cmd.CommandLong(EnableSubCmd.Name, EnableSubCmd.ShortHelp, EnableSubCmd.LongHelp, EnableSubCmd.CmdFunc(settings))
+			cmd.CommandLong(ShowSubCmd.Name, ShowSubCmd.ShortHelp, ShowSubCmd.LongHelp, ShowSubCmd.CmdFunc(settings))
+		}
+	},
+}
+
+var DisableSubCmd = models.Command{
+	Name:      "disable",
+	ShortHelp: "Disable maintenance mode for a code service",
+	LongHelp: "`maintenance disable` turns off maintenance mode for a given code service. " +
+		"Here is a sample command\n\n" +
+		"```\ncatalyze -E \"<your_env_alias>\" maintenance disable code-1\n```",
+	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
+		return func(subCmd *cli.Cmd) {
+			serviceName := subCmd.StringArg("SERVICE_NAME", "", "The name of the service to disable maintenance mode for")
+			subCmd.Action = func() {
+				if _, err := auth.New(settings, prompts.New()).Signin(); err != nil {
+					logrus.Fatal(err.Error())
+				}
+				if err := config.CheckRequiredAssociation(true, true, settings); err != nil {
+					logrus.Fatal(err.Error())
+				}
+				err := CmdDisable(*serviceName, New(settings), services.New(settings))
+				if err != nil {
+					logrus.Fatal(err.Error())
+				}
+			}
+			subCmd.Spec = "SERVICE_NAME"
+		}
+	},
+}
+
+var EnableSubCmd = models.Command{
+	Name:      "enable",
+	ShortHelp: "Enable maintenance mode for a code service",
+	LongHelp: "`maintenance enable` turns on maintenance mode for a given code service. " +
+		"Maintenance mode redirects all traffic for the given code service to a default HTTP maintenance page. " +
+		"If you would like to customize this maintenance page, please contact Catalyze support. " +
+		"Here is a sample command\n\n" +
+		"```\ncatalyze -E \"<your_env_alias>\" maintenance enable code-1\n```",
+	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
+		return func(subCmd *cli.Cmd) {
+			serviceName := subCmd.StringArg("SERVICE_NAME", "", "The name of the code service to enable maintenance mode for")
+			subCmd.Action = func() {
+				if _, err := auth.New(settings, prompts.New()).Signin(); err != nil {
+					logrus.Fatal(err.Error())
+				}
+				if err := config.CheckRequiredAssociation(true, true, settings); err != nil {
+					logrus.Fatal(err.Error())
+				}
+				err := CmdEnable(*serviceName, New(settings), services.New(settings))
+				if err != nil {
+					logrus.Fatal(err.Error())
+				}
+			}
+			subCmd.Spec = "SERVICE_NAME"
+		}
+	},
+}
+
+var ShowSubCmd = models.Command{
+	Name:      "show",
+	ShortHelp: "Show the status of maintenance mode for a code service",
+	LongHelp: "`maintenance show` displays whether or not maintenance mode is enabled " +
+		"for a code service or all code services. " +
+		"Here are some sample commands\n\n" +
+		"```\ncatalyze -E \"<your_env_alias>\" maintenance show\n" +
+		"catalyze -E \"<your_env_alias>\" maintenance show code-1\n```",
+	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
+		return func(subCmd *cli.Cmd) {
+			serviceName := subCmd.StringArg("SERVICE_NAME", "", "The name of the code service to show the status of maintenance mode")
+			subCmd.Action = func() {
+				if _, err := auth.New(settings, prompts.New()).Signin(); err != nil {
+					logrus.Fatal(err.Error())
+				}
+				if err := config.CheckRequiredAssociation(true, true, settings); err != nil {
+					logrus.Fatal(err.Error())
+				}
+				err := CmdShow(*serviceName, settings.EnvironmentID, settings.Pod, New(settings), services.New(settings))
+				if err != nil {
+					logrus.Fatal(err.Error())
+				}
+			}
+			subCmd.Spec = "[SERVICE_NAME]"
+		}
+	},
+}
+
+// IMaintenance
+type IMaintenance interface {
+	Enable(svcProxyID, upstreamID string) error
+	Disable(svcProxyID, upstreamID string) error
+	List(svcProxyID string) (*[]models.Maintenance, error)
+}
+
+// SMaintenance is a concrete implementation of IMaintenance
+type SMaintenance struct {
+	Settings *models.Settings
+}
+
+// New returns an instance of IMetrics
+func New(settings *models.Settings) IMaintenance {
+	return &SMaintenance{
+		Settings: settings,
+	}
+}

--- a/commands/maintenance/disable.go
+++ b/commands/maintenance/disable.go
@@ -9,14 +9,15 @@ import (
 )
 
 func CmdDisable(svcName string, im IMaintenance, is services.IServices) error {
-	// TODO need a way to determine if maintenance mode is available for an environment
-	// preferrably without hardcoding
 	upstreamService, err := is.RetrieveByLabel(svcName)
 	if err != nil {
 		return err
 	}
 	if upstreamService == nil {
 		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
+	}
+	if upstreamService.Type != "code" {
+		return fmt.Errorf("Maintenance mode can only be disabled for code services, not %s services", upstreamService.Type)
 	}
 
 	serviceProxy, err := is.RetrieveByLabel("service_proxy")

--- a/commands/maintenance/disable.go
+++ b/commands/maintenance/disable.go
@@ -1,0 +1,56 @@
+package maintenance
+
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/catalyzeio/cli/commands/services"
+	"github.com/catalyzeio/cli/lib/httpclient"
+)
+
+func CmdDisable(svcName string, im IMaintenance, is services.IServices) error {
+	// TODO need a way to determine if maintenance mode is available for an environment
+	// preferrably without hardcoding
+	upstreamService, err := is.RetrieveByLabel(svcName)
+	if err != nil {
+		return err
+	}
+	if upstreamService == nil {
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
+	}
+
+	serviceProxy, err := is.RetrieveByLabel("service_proxy")
+	if err != nil {
+		return err
+	}
+
+	svcMaintenance, err := im.List(serviceProxy.ID)
+	if err != nil {
+		return err
+	}
+	enabled := false
+	for _, mm := range *svcMaintenance {
+		if mm.UpstreamID == upstreamService.ID {
+			enabled = true
+		}
+	}
+	if !enabled {
+		return fmt.Errorf("Maintenance mode is not currently enabled for the service %s", svcName)
+	}
+
+	err = im.Disable(serviceProxy.ID, upstreamService.ID)
+	if err != nil {
+		return err
+	}
+	logrus.Printf("Maintenance mode disabled for service %s (ID = %s)", upstreamService.Label, upstreamService.ID)
+	return nil
+}
+
+func (m *SMaintenance) Disable(svcProxyID, upstreamID string) error {
+	headers := httpclient.GetHeaders(m.Settings.SessionToken, m.Settings.Version, m.Settings.Pod, m.Settings.UsersID)
+	resp, statusCode, err := httpclient.Delete(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/maintenance?upstream=%s", m.Settings.PaasHost, m.Settings.PaasHostVersion, m.Settings.EnvironmentID, svcProxyID, upstreamID), headers)
+	if err != nil {
+		return err
+	}
+	return httpclient.ConvertResp(resp, statusCode, nil)
+}

--- a/commands/maintenance/enable.go
+++ b/commands/maintenance/enable.go
@@ -1,0 +1,50 @@
+package maintenance
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/catalyzeio/cli/commands/services"
+	"github.com/catalyzeio/cli/lib/httpclient"
+)
+
+func CmdEnable(svcName string, im IMaintenance, is services.IServices) error {
+	// TODO need a way to determine if maintenance mode is available for an environment
+	// preferrably without hardcoding
+	upstreamService, err := is.RetrieveByLabel(svcName)
+	if err != nil {
+		return err
+	}
+	if upstreamService == nil {
+		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
+	}
+
+	serviceProxy, err := is.RetrieveByLabel("service_proxy")
+	if err != nil {
+		return err
+	}
+
+	err = im.Enable(serviceProxy.ID, upstreamService.ID)
+	if err != nil {
+		return err
+	}
+	logrus.Printf("Maintenance mode enabled for service %s (ID = %s)", upstreamService.Label, upstreamService.ID)
+	return nil
+}
+
+func (m *SMaintenance) Enable(svcProxyID, upstreamID string) error {
+	body := map[string]string{
+		"upstream": upstreamID,
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	headers := httpclient.GetHeaders(m.Settings.SessionToken, m.Settings.Version, m.Settings.Pod, m.Settings.UsersID)
+	resp, statusCode, err := httpclient.Post(b, fmt.Sprintf("%s%s/environments/%s/services/%s/maintenance", m.Settings.PaasHost, m.Settings.PaasHostVersion, m.Settings.EnvironmentID, svcProxyID), headers)
+	if err != nil {
+		return err
+	}
+	return httpclient.ConvertResp(resp, statusCode, nil)
+}

--- a/commands/maintenance/enable.go
+++ b/commands/maintenance/enable.go
@@ -10,14 +10,15 @@ import (
 )
 
 func CmdEnable(svcName string, im IMaintenance, is services.IServices) error {
-	// TODO need a way to determine if maintenance mode is available for an environment
-	// preferrably without hardcoding
 	upstreamService, err := is.RetrieveByLabel(svcName)
 	if err != nil {
 		return err
 	}
 	if upstreamService == nil {
 		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"catalyze services\" command.", svcName)
+	}
+	if upstreamService.Type != "code" {
+		return fmt.Errorf("Maintenance mode can only be enabled for code services, not %s services", upstreamService.Type)
 	}
 
 	serviceProxy, err := is.RetrieveByLabel("service_proxy")

--- a/commands/maintenance/show.go
+++ b/commands/maintenance/show.go
@@ -30,7 +30,7 @@ func CmdShow(svcName, envID, podID string, im IMaintenance, is services.IService
 
 	data := [][]string{{"SERVICE", "MAINTENANCE MODE", "ENABLED AT"}}
 	for _, svc := range *svcs {
-		if (svcName == "" && svc.Name == "code") || svc.Label == svcName {
+		if svc.Type == "code" && (svcName == "" || svc.Label == svcName) {
 			createdAt := ""
 			status := "disabled"
 			for _, mm := range *svcMaintenance {

--- a/commands/maintenance/show.go
+++ b/commands/maintenance/show.go
@@ -1,0 +1,76 @@
+package maintenance
+
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/catalyzeio/cli/commands/services"
+	"github.com/catalyzeio/cli/lib/httpclient"
+	"github.com/catalyzeio/cli/models"
+	"github.com/olekukonko/tablewriter"
+)
+
+func CmdShow(svcName, envID, podID string, im IMaintenance, is services.IServices) error {
+	svcs, err := is.ListByEnvID(envID, podID)
+	if err != nil {
+		return err
+	}
+	if svcs == nil || len(*svcs) == 0 {
+		logrus.Println("No services found")
+		return nil
+	}
+	serviceProxy, err := is.RetrieveByLabel("service_proxy")
+	if err != nil {
+		return err
+	}
+	svcMaintenance, err := im.List(serviceProxy.ID)
+	if err != nil {
+		return err
+	}
+
+	data := [][]string{{"SERVICE", "MAINTENANCE MODE", "ENABLED AT"}}
+	for _, svc := range *svcs {
+		if (svcName == "" && svc.Name == "code") || svc.Label == svcName {
+			createdAt := ""
+			status := "disabled"
+			for _, mm := range *svcMaintenance {
+				if mm.UpstreamID == svc.ID {
+					createdAt = mm.CreatedAt
+					status = "enabled"
+				}
+			}
+			data = append(data, []string{svc.Label, status, createdAt})
+		}
+	}
+	if len(data) == 1 {
+		if svcName == "" {
+			logrus.Println("No code services found")
+		} else {
+			logrus.Printf("No code service found with the label %s", svcName)
+		}
+		return nil
+	}
+	table := tablewriter.NewWriter(logrus.StandardLogger().Out)
+	table.SetBorder(false)
+	table.SetRowLine(false)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.AppendBulk(data)
+	table.Render()
+	return nil
+}
+
+func (m *SMaintenance) List(svcProxyID string) (*[]models.Maintenance, error) {
+	headers := httpclient.GetHeaders(m.Settings.SessionToken, m.Settings.Version, m.Settings.Pod, m.Settings.UsersID)
+	resp, statusCode, err := httpclient.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/maintenance", m.Settings.PaasHost, m.Settings.PaasHostVersion, m.Settings.EnvironmentID, svcProxyID), headers)
+	if err != nil {
+		return nil, err
+	}
+	var maintenance []models.Maintenance
+	err = httpclient.ConvertResp(resp, statusCode, &maintenance)
+	if err != nil {
+		return nil, err
+	}
+	return &maintenance, nil
+}

--- a/models/models.go
+++ b/models/models.go
@@ -320,3 +320,8 @@ type Workers struct {
 	Limit   int            `json:"worker_limit,omitempty"`
 	Workers map[string]int `json:"workers"`
 }
+
+type Maintenance struct {
+	UpstreamID string `json:"upstream"`
+	CreatedAt  string `json:"createdAt"`
+}


### PR DESCRIPTION
Help text:

```
$ cli maintenance --help

Usage: catalyze maintenance COMMAND [arg...]

Manage maintenance mode for code services

Commands:
  disable	Disable maintenance mode for a code service
  enable	Enable maintenance mode for a code service
  show	Show the status of maintenance mode for a code service

Run 'catalyze maintenance COMMAND --help' for more information on a command.
------------------------------------------------------------
$ cli maintenance disable --help

Usage: catalyze maintenance disable SERVICE_NAME

`maintenance disable` turns off maintenance mode for a given code service. Here is a sample command

`
catalyze -E "<your_env_alias>" maintenance disable code-1
`

Arguments:
  SERVICE_NAME=""   The name of the service to disable maintenance mode for
------------------------------------------------------------
$ cli maintenance enable --help

Usage: catalyze maintenance enable SERVICE_NAME

`maintenance enable` turns on maintenance mode for a given code service. Maintenance mode redirects all traffic for the given code service to a default HTTP maintenance page. If you would like to customize this maintenance page, please contact Catalyze support. Here is a sample command

`
catalyze -E "<your_env_alias>" maintenance enable code-1
`

Arguments:
  SERVICE_NAME=""   The name of the code service to enable maintenance mode for
------------------------------------------------------------
$ cli maintenance show --help

Usage: catalyze maintenance show [SERVICE_NAME]

`maintenance show` displays whether or not maintenance mode is enabled for a code service or all code services. Here are some sample commands

`
catalyze -E "<your_env_alias>" maintenance show
catalyze -E "<your_env_alias>" maintenance show code-1
`

Arguments:
  SERVICE_NAME=""   The name of the code service to show the status of maintenance mode
```

Sample output: 

```
$ cli -E <alias> maintenance show
  SERVICE  MAINTENANCE MODE  ENABLED AT  
  app01    disabled                      

$ cli -E <alias> maintenance show app01
  SERVICE  MAINTENANCE MODE  ENABLED AT  
  app01    disabled                      

$ cli -E <alias> maintenance enable app01
Maintenance mode enabled for service app01 (ID = 77bc1a8d-1d70-4a0a-8207-11809205c5df)

$ cli -E <alias> maintenance enable app01
[fatal] (99002) Maintenance Mode Already Enabled: Maintenance mode for the upstream service has already been enabled.

$ cli -E <alias> maintenance show
  SERVICE  MAINTENANCE MODE  ENABLED AT           
  app01    enabled           2017-01-03T14:54:43  

$ cli -E <alias> maintenance disable app01
Maintenance mode disabled for service app01 (ID = 77bc1a8d-1d70-4a0a-8207-11809205c5df)

$ cli -E <alias> maintenance disable app01
[fatal] Maintenance mode is not currently enabled for the service app01
```