### PR TITLE
Releases documentation change

### DIFF
--- a/commands/releases/contract.go
+++ b/commands/releases/contract.go
@@ -18,6 +18,7 @@ var Cmd = models.Command{
 		"A release is automatically created each time you perform a git push. " +
 		"The release is tagged with the git SHA of the commit. " +
 		"Releases are a way of tagging specific points in time of your git history. " +
+		"The last three releases will be retained. " +
 		"You can rollback to a specific release by using the [rollback](#rollback) command. " +
 		"The releases command cannot be run directly but has sub commands.",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {


### PR DESCRIPTION
COPS-863, we should specify that we will only be keeping the last three releases.  We prune the previous releases to save on disk space on docker registry